### PR TITLE
Add some built-in 404 handling middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`.
   - `start`: Whether to automatically start the application. Defaults to `true`
 
+### `origamiService.middleware.notFound( [message] )`
+
+Create and return a middleware for throwing `404` "Not Found" errors. The returned middleware will pass on an error which can be caught later by an error handling middleware. The error will have a `status` property set to `404` so that your error handler can differentiate it from other errors.
+
+This middleware should be mounted after all of your application routes:
+
+```js
+// routes go here
+app.use(origamiService.middleware.notFound());
+// error handler goes here
+```
+
+By default, the error message will be set to `'Not Found'`. If you wish to specify a custom message you can specify one as a parameter:
+
+```js
+app.use(origamiService.middleware.notFound('This page does not exist'));
+```
+
 ### Examples
 
 You can find example implementations of Origami-compliant services in the `examples` folder of this repo:
@@ -87,6 +105,12 @@ You can find example implementations of Origami-compliant services in the `examp
 
     ```sh
     node examples/options
+    ```
+
+  - **Middleware:** start an Origami service using some of the built-in middleware:
+
+    ```sh
+    node examples/middleware
     ```
 
 

--- a/example/middleware/index.js
+++ b/example/middleware/index.js
@@ -22,6 +22,9 @@ origamiService({
 			response.send('Hello World!');
 		});
 
+		// Mount some error handling middleware
+		app.use(origamiService.middleware.notFound('The requested page does not exist'));
+
 	})
 
 	// Catch and log any startup errors

--- a/example/middleware/public/example.txt
+++ b/example/middleware/public/example.txt
@@ -1,0 +1,1 @@
+This file should be served static.

--- a/example/options/index.js
+++ b/example/options/index.js
@@ -11,12 +11,19 @@ origamiService({
 	port: 8765
 })
 
-	// When the service starts log that everything
-	// is OK and output the address
+	// When the service starts...
 	.then(app => {
+
+		// log that everything is OK and output the address
 		const port = app.origami.server.address().port;
 		const address = `http://localhost:${port}/`;
 		console.log(`Application started: ${address}`);
+
+		// Create a route
+		app.get('/', (request, response) => {
+			response.send('Hello World!');
+		});
+
 	})
 
 	// Catch and log any startup errors

--- a/lib/middleware/not-found.js
+++ b/lib/middleware/not-found.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = notFound;
+
+function notFound(message) {
+	return (request, response, next) => {
+		next(httpError(404, message));
+	};
+}

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -3,6 +3,7 @@
 const defaults = require('lodash/defaultsDeep');
 const express = require('express');
 const morgan = require('morgan');
+const notFound = require('./middleware/not-found');
 const path = require('path');
 
 module.exports = origamiService;
@@ -14,6 +15,11 @@ module.exports.defaults = {
 	region: 'EU',
 	requestLogFormat: 'combined',
 	start: true
+};
+
+// Middleware exports
+module.exports.middleware = {
+	notFound
 };
 
 // Function to create an Origami Service app

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "express": "^4.14.0",
+    "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
     "morgan": "^1.7.0"
   },

--- a/test/unit/lib/middleware/not-found.js
+++ b/test/unit/lib/middleware/not-found.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/not-found', () => {
+	let express;
+	let httpError;
+	let notFound;
+
+	beforeEach(() => {
+		express = require('../../mock/express.mock');
+
+		httpError = require('../../mock/http-errors.mock');
+		mockery.registerMock('http-errors', httpError);
+
+		notFound = require('../../../../lib/middleware/not-found');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(notFound);
+	});
+
+	describe('notFound(message)', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = notFound('mock message');
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('creates a 404 HTTP error with the specified message', () => {
+				assert.calledOnce(httpError);
+				assert.calledWithExactly(httpError, 404, 'mock message');
+			});
+
+			it('calls `next` with the created error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next, httpError.mockError);
+			});
+
+		});
+
+		describe('when `message` is not defined', () => {
+
+			beforeEach(() => {
+				middleware = notFound();
+			});
+
+			describe('middleware(request, response, next)', () => {
+				let next;
+
+				beforeEach(() => {
+					next = sinon.spy();
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('creates a 404 HTTP error with no custom message', () => {
+					assert.calledOnce(httpError);
+					assert.calledWithExactly(httpError, 404, undefined);
+				});
+
+				it('calls `next` with the created error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, httpError.mockError);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -8,6 +8,7 @@ describe('lib/origami-service', () => {
 	let express;
 	let defaults;
 	let morgan;
+	let notFound;
 	let origamiService;
 
 	beforeEach(() => {
@@ -19,6 +20,9 @@ describe('lib/origami-service', () => {
 
 		morgan = require('../mock/morgan.mock');
 		mockery.registerMock('morgan', morgan);
+
+		notFound = sinon.stub();
+		mockery.registerMock('./middleware/not-found', notFound);
 
 		origamiService = require('../../..');
 	});
@@ -55,6 +59,18 @@ describe('lib/origami-service', () => {
 
 		it('has a `start` property', () => {
 			assert.strictEqual(origamiService.defaults.start, true);
+		});
+
+	});
+
+	it('has a `middleware` property', () => {
+		assert.isObject(origamiService.middleware);
+	});
+
+	describe('.middleware', () => {
+
+		it('has a `notFound` property which references `lib/middleware/not-found`', () => {
+			assert.strictEqual(origamiService.middleware.notFound, notFound);
 		});
 
 	});

--- a/test/unit/mock/http-errors.mock.js
+++ b/test/unit/mock/http-errors.mock.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const httpError = module.exports = sinon.stub();
+const mockError = httpError.mockError = sinon.stub();
+
+httpError.returns(mockError);


### PR DESCRIPTION
I've added this as an example of how we could bundle middleware with the module, reducing copy/paste between different services. I'm adding the 404 middleware _without_ an error handler for now just to demo it, but I think a full error handler would be good to bundle in later.