### PR TITLE
Add in Sentry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `port/PORT`: The port that the application should run on. Defaults to `8080`.
   - `region/REGION`: The region to use in logging and reporting for the application. Defaults to `'EU'`
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`
+  - `sentryDsn/SENTRY_DSN`: The [Sentry] DSN to send errors to. If set to `null`, errors will not be sent to Sentry. Defaults to `null`. The `SENTRY_DSN` environment variable is aliased as `RAVEN_URL`
   - `start`: Whether to automatically start the application. Defaults to `true`
 
 ### `origamiService.middleware.notFound( [message] )`
@@ -101,6 +102,18 @@ By default, the error message will be set to `'Not Found'`. If you wish to speci
 
 ```js
 app.use(origamiService.middleware.notFound('This page does not exist'));
+```
+
+### `origamiService.middleware.errorHandler()`
+
+Create and return a middleware for rendering errors that occur in the application routes. The returned middleware logs errors to [Sentry] (if the `sentryDsn` option is present) and then renders an error page. It uses the `status` property of an error to decide on which error type to render.
+
+This middleware should be mounted after all of your application routes, and is useful in conjuction with `origamiService.middleware.notFound`:
+
+```js
+// routes go here
+app.use(origamiService.middleware.notFound());
+app.use(origamiService.middleware.errorHandler());
 ```
 
 ### Examples
@@ -162,4 +175,5 @@ This software is published by the Financial Times under the [MIT licence][licens
 [npm]: https://www.npmjs.com/
 [origami support]: mailto:origami-support@ft.com
 [promises]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[sentry]: https://sentry.io/
 [static]: https://expressjs.com/en/starter/static-files.html

--- a/example/middleware/index.js
+++ b/example/middleware/index.js
@@ -20,6 +20,7 @@ origamiService({
 
 		// Mount some error handling middleware
 		app.use(origamiService.middleware.notFound('The requested page does not exist'));
+		app.use(origamiService.middleware.errorHandler());
 
 	})
 

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const raven = require('raven');
+
+module.exports = errorHandler;
+
+function errorHandler() {
+
+	// Handler for sending errors to Sentry
+	const ravenErrorHandler = raven.errorHandler();
+
+	// Handler for rendering to the user
+	function standardErrorHandler(error, request, response) {
+		const origami = request.app.origami;
+		const status = error.status || error.statusCode || error.status_code || 500;
+
+		// TODO switch this to use Handlebars when it's added
+		if (status >= 500) {
+			origami.log.error(`Error: ${error.message}`);
+		}
+		let stack = '';
+		if (status >= 500 && origami.options.environment !== 'production') {
+			stack = `<pre>${error.stack}</pre>`;
+		}
+		response.status(status).send(`
+			<h1>Error ${status}</h1>
+			<p>${error.message}</p>
+			${stack}
+		`);
+	}
+
+	// Decide on which handler to use based on
+	// whether Sentry has been configured
+	return (error, request, response, next) => {
+		if (request.app.origami.options.sentryDsn) {
+			return ravenErrorHandler(error, request, response, error => {
+				standardErrorHandler(error, request, response, next);
+			});
+		}
+		standardErrorHandler(error, request, response, next);
+	};
+
+}

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const defaults = require('lodash/defaults');
+const errorHandler = require('./middleware/error-handler');
 const express = require('express');
 const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
 const path = require('path');
+const raven = require('raven');
 
 module.exports = origamiService;
 
@@ -16,11 +18,13 @@ module.exports.defaults = {
 	port: 8080,
 	region: 'EU',
 	requestLogFormat: 'combined',
+	sentryDsn: null,
 	start: true
 };
 
 // Middleware exports
 module.exports.middleware = {
+	errorHandler,
 	notFound
 };
 
@@ -37,6 +41,12 @@ function origamiService(options) {
 
 	// Create the Express application
 	const app = createExpressApp(options, paths);
+
+	// Set up Raven/Sentry request middleware
+	if (options.sentryDsn) {
+		raven.config(options.sentryDsn).install();
+		app.use(raven.requestHandler());
+	}
 
 	// Set up a request logger
 	if (options.requestLogFormat) {
@@ -70,7 +80,8 @@ function defaultOptions(options) {
 	const environmentOptions = {
 		environment: process.env.NODE_ENV,
 		port: process.env.PORT,
-		region: process.env.REGION
+		region: process.env.REGION,
+		sentryDsn: process.env.SENTRY_DSN || process.env.RAVEN_URL
 	};
 	return defaults({}, options, environmentOptions, module.exports.defaults);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "express": "^4.14.0",
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
-    "morgan": "^1.7.0"
+    "morgan": "^1.7.0",
+    "raven": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/test/unit/lib/middleware/error-handler.js
+++ b/test/unit/lib/middleware/error-handler.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/error-handler', () => {
+	let express;
+	let errorHandler;
+	let log;
+	let raven;
+
+	beforeEach(() => {
+		express = require('../../mock/express.mock');
+
+		log = require('../../mock/log.mock');
+
+		raven = require('../../mock/raven.mock');
+		mockery.registerMock('raven', raven);
+
+		errorHandler = require('../../../../lib/middleware/error-handler');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(errorHandler);
+	});
+
+	describe('errorHandler()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = errorHandler();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(error, request, response, next)', () => {
+			let error;
+			let next;
+
+			beforeEach(() => {
+				express.mockRequest.app.origami = {
+					log,
+					options: {
+						sentryDsn: 'mock-sentry-dsn'
+					}
+				};
+				error = new Error('Oops');
+				next = sinon.spy();
+				raven.mockErrorMiddleware.yields(error);
+				middleware(error, express.mockRequest, express.mockResponse, next);
+			});
+
+			it('creates a Raven error handler middleware', () => {
+				assert.calledOnce(raven.errorHandler);
+			});
+
+			it('calls the Raven error handler middleware with the expected arguments', () => {
+				assert.calledOnce(raven.mockErrorMiddleware);
+				assert.calledWith(raven.mockErrorMiddleware, error, express.mockRequest, express.mockResponse);
+			});
+
+			it('logs the error', () => {
+				assert.calledWithExactly(log.error, 'Error: Oops');
+			});
+
+			it('sends an error status code', () => {
+				assert.calledOnce(express.mockResponse.status);
+				assert.calledWithExactly(express.mockResponse.status, 500);
+			});
+
+			it('responds with an HTML representation of the error', () => {
+				assert.calledOnce(express.mockResponse.send);
+				const sentData = express.mockResponse.send.firstCall.args[0];
+				assert.match(sentData, /<h1>Error 500<\/h1>/);
+				assert.match(sentData, /<p>Oops<\/p>/);
+				assert.include(sentData, error.stack);
+			});
+
+			describe('when `request.app.origami.options.sentryDsn` is not defined', () => {
+
+				beforeEach(() => {
+					express.mockResponse.status.reset();
+					express.mockResponse.send.reset();
+					raven.mockErrorMiddleware.reset();
+					delete express.mockRequest.app.origami.options.sentryDsn;
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not call the Raven error handler middleware', () => {
+					assert.notCalled(raven.mockErrorMiddleware);
+				});
+
+				it('sends an error status code', () => {
+					assert.calledOnce(express.mockResponse.status);
+					assert.calledWithExactly(express.mockResponse.status, 500);
+				});
+
+				it('responds with an HTML representation of the error', () => {
+					assert.calledOnce(express.mockResponse.send);
+					const sentData = express.mockResponse.send.firstCall.args[0];
+					assert.match(sentData, /<h1>Error 500<\/h1>/);
+					assert.match(sentData, /<p>Oops<\/p>/);
+					assert.include(sentData, error.stack);
+				});
+
+			});
+
+			describe('when `request.app.origami.options.environment` is "production"', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.reset();
+					express.mockRequest.app.origami.options.environment = 'production';
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not include the stack in the HTML representation of the error', () => {
+					assert.calledOnce(express.mockResponse.send);
+					const sentData = express.mockResponse.send.firstCall.args[0];
+					assert.notInclude(sentData, error.stack);
+				});
+
+			});
+
+			describe('when `error.status` is set', () => {
+
+				beforeEach(() => {
+					error.status = 567;
+					express.mockResponse.status.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sends the given status code to the user', () => {
+					assert.calledOnce(express.mockResponse.status);
+					assert.calledWithExactly(express.mockResponse.status, 567);
+				});
+
+			});
+
+			describe('when `error.statusCode` is set', () => {
+
+				beforeEach(() => {
+					error.statusCode = 567;
+					express.mockResponse.status.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sends the given status code to the user', () => {
+					assert.calledOnce(express.mockResponse.status);
+					assert.calledWithExactly(express.mockResponse.status, 567);
+				});
+
+			});
+
+			describe('when `error.status_code` is set', () => {
+
+				beforeEach(() => {
+					error.status_code = 567;
+					express.mockResponse.status.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sends the given status code to the user', () => {
+					assert.calledOnce(express.mockResponse.status);
+					assert.calledWithExactly(express.mockResponse.status, 567);
+				});
+
+			});
+
+			describe('when the error status is below 500', () => {
+
+				beforeEach(() => {
+					error.status = 499;
+					log.error.reset();
+					express.mockResponse.send.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not log the error', () => {
+					assert.neverCalledWith(log.error, 'Error: Oops');
+				});
+
+				it('does not include the stack in the HTML representation of the error', () => {
+					const sentData = express.mockResponse.send.firstCall.args[0];
+					assert.notInclude(sentData, error.stack);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/express.mock.js
+++ b/test/unit/mock/express.mock.js
@@ -22,6 +22,7 @@ express.mockStaticMiddleware = sinon.stub();
 express.static.returns(express.mockStaticMiddleware);
 
 express.mockRequest = {
+	app: mockApp,
 	headers: {},
 	path: '/',
 	query: {},

--- a/test/unit/mock/raven.mock.js
+++ b/test/unit/mock/raven.mock.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const raven = module.exports = {
+	config: sinon.stub(),
+	install: sinon.stub()
+};
+const mockRequestMiddleware = raven.mockRequestMiddleware = sinon.stub();
+const mockErrorMiddleware = raven.mockErrorMiddleware = sinon.stub();
+
+raven.config.returns(raven);
+raven.install.returns(raven);
+raven.requestHandler = sinon.stub().returns(mockRequestMiddleware);
+raven.errorHandler = sinon.stub().returns(mockErrorMiddleware);


### PR DESCRIPTION
Full support requires that an application mounts the built-in error
handling middleware after all of their routes.

Resolves #4.