### PR TITLE
Add Handlebars as a view engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ test-unit:
 	@$(DONE)
 
 test-unit-coverage:
-	@NODE_ENV=test nyc node_modules/.bin/_mocha test/unit --recursive
+	@NODE_ENV=test nyc --reporter=text --reporter=html node_modules/.bin/_mocha test/unit --recursive
 	@$(DONE)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ origamiService({
 });
 ```
 
-The Express application will have some additional properties, added by the Origami Service module:
+The Express application will have some additional properties, added by the Origami Service module. These will also be added to `app.locals` so they're available in your views.
 
   - `app.origami.options`: The defaulted [options](#options) passed into the `origamiService` call
   - `app.origami.server`: The [HTTP Server] which was returned by `app.listen`
@@ -60,6 +60,10 @@ The following [Express settings] will be set:
 
   - `json spaces`: Configured to prettify output JSON
   - `x-powered-by`: Disabled
+  - `views`: Configured to the `views` folder
+  - `view engine`: Configured to use [Handlebars]
+
+[Handlebars] will be used as a view engine with the extension `.html`. We use [Express Handlebars] for this, which means layouts and partials are supported. Add layouts and partials to `views/layouts` and `views/partials` respectively. See [the examples](#examples) for more information.
 
 Some middleware will also be mounted by default, in this order:
 
@@ -77,6 +81,7 @@ The Origami Service module can be configured with a variety of options, passed i
 The available options are as follows. Where two names are separated by a `/`, the first is the object key and the second is the environment variable:
 
   - `basePath`: The base path of the application, which paths (e.g. public files) will be relative to. Defaults to `process.cwd()`
+  - `defaultLayout`: The default layout file to use in view rendering. This should be the name of an HTML file in the `views/layouts` directory, e.g. `'main'` would map to `views/layouts/main.html`. Defaults to `false`
   - `environment/NODE_ENV`: The environment to run in. This affects things like public file max ages. One of `'production'`, `'development'`, or `'test'`. Defaults to `'development'`
   - `log`: A console object used to output non-request logs. Defaults to the global `console` object
   - `name`: The human-readable name of the application, used in logging. Defaults to `'Origami Service'`
@@ -108,13 +113,15 @@ app.use(origamiService.middleware.notFound('This page does not exist'));
 
 Create and return a middleware for rendering errors that occur in the application routes. The returned middleware logs errors to [Sentry] (if the `sentryDsn` option is present) and then renders an error page. It uses the `status` property of an error to decide on which error type to render.
 
-This middleware should be mounted after all of your application routes, and is useful in conjuction with `origamiService.middleware.notFound`:
+This middleware should be mounted after all of your application routes, and is useful in conjunction with `origamiService.middleware.notFound`:
 
 ```js
 // routes go here
 app.use(origamiService.middleware.notFound());
 app.use(origamiService.middleware.errorHandler());
 ```
+
+The error handling middleware will look for a Handlebars template in `views/error.html` and use it to render the page. If no template is found in that location then it falls back to basic HTML output. This allows you to style your error pages and use your application's default layout.
 
 ### Examples
 
@@ -138,6 +145,11 @@ You can find example implementations of Origami-compliant services in the `examp
     node examples/middleware
     ```
 
+  - **Views:** start an Origami service with partials and layouts:
+
+    ```sh
+    node examples/views
+    ```
 
 Contributing
 ------------
@@ -166,7 +178,9 @@ This software is published by the Financial Times under the [MIT licence][licens
 [#ft-origami]: https://financialtimes.slack.com/messages/ft-origami/
 [environment variables]: https://en.wikipedia.org/wiki/Environment_variable
 [express]: http://expressjs.com/
+[express handlebars]: https://github.com/ericf/express-handlebars
 [express settings]: https://expressjs.com/en/4x/api.html#app.settings.table
+[handlebars]: http://handlebarsjs.com/
 [http server]: https://nodejs.org/api/http.html#http_class_http_server
 [issues]: https://github.com/Financial-Times/origami-service/issues
 [license]: http://opensource.org/licenses/MIT

--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -15,7 +15,7 @@ origamiService({
 
 		// Create a route
 		app.get('/', (request, response) => {
-			response.send('Hello World!');
+			response.render('index');
 		});
 
 	})

--- a/example/basic/views/index.html
+++ b/example/basic/views/index.html
@@ -1,0 +1,4 @@
+
+<h1>{{origami.options.name}}</h1>
+
+<p>Hello World!</p>

--- a/example/middleware/views/index.html
+++ b/example/middleware/views/index.html
@@ -1,0 +1,4 @@
+
+<h1>{{origami.options.name}}</h1>
+
+<p>Hello World!</p>

--- a/example/options/index.js
+++ b/example/options/index.js
@@ -17,7 +17,7 @@ origamiService({
 
 		// Create a route
 		app.get('/', (request, response) => {
-			response.send('Hello World!');
+			response.render('index');
 		});
 
 	})

--- a/example/options/views/index.html
+++ b/example/options/views/index.html
@@ -1,0 +1,4 @@
+
+<h1>{{origami.options.name}}</h1>
+
+<p>Hello World!</p>

--- a/example/views/index.js
+++ b/example/views/index.js
@@ -4,10 +4,12 @@
 // full module name: @financial-times/origami-service)
 const origamiService = require('../..');
 
-// Create and run an Origami service
+// Create and run an Origami service with some
+// overridden options
 origamiService({
-	name: 'Origami Service Middleware Example',
-	basePath: __dirname
+	name: 'Origami Service Views Example',
+	basePath: __dirname,
+	defaultLayout: 'main'
 })
 
 	// When the service starts...
@@ -15,7 +17,9 @@ origamiService({
 
 		// Create a route
 		app.get('/', (request, response) => {
-			response.render('index');
+			response.render('index', {
+				message: 'This text is in the route.'
+			});
 		});
 
 		// Mount some error handling middleware

--- a/example/views/public/example.txt
+++ b/example/views/public/example.txt
@@ -1,0 +1,1 @@
+This file should be served static.

--- a/example/views/views/error.html
+++ b/example/views/views/error.html
@@ -1,0 +1,8 @@
+
+<h1>Error {{error.status}}</h1>
+
+<p>{{error.message}}</p>
+
+{{#if error.stack}}
+	<pre>{{error.stack}}</pre>
+{{/if}}

--- a/example/views/views/index.html
+++ b/example/views/views/index.html
@@ -1,0 +1,8 @@
+
+<h1>{{origami.options.name}}</h1>
+
+<p>This text is in the view.</p>
+
+<p>{{message}}</p>
+
+{{>example}}

--- a/example/views/views/layouts/main.html
+++ b/example/views/views/layouts/main.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>{{origami.options.name}}</title>
+	</head>
+	<body>
+
+		{{{body}}}
+
+		<p>This text is in the layout.</p>
+
+	</body>
+</html>

--- a/example/views/views/partials/example.html
+++ b/example/views/views/partials/example.html
@@ -1,0 +1,2 @@
+
+<p>This text is in a partial.</p>

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -13,20 +13,36 @@ function errorHandler() {
 	function standardErrorHandler(error, request, response) {
 		const origami = request.app.origami;
 		const status = error.status || error.statusCode || error.status_code || 500;
+		const showStack = (status >= 500 && origami.options.environment !== 'production');
 
-		// TODO switch this to use Handlebars when it's added
+		// Log server errors
 		if (status >= 500) {
 			origami.log.error(`Error: ${error.message}`);
 		}
-		let stack = '';
-		if (status >= 500 && origami.options.environment !== 'production') {
-			stack = `<pre>${error.stack}</pre>`;
-		}
-		response.status(status).send(`
-			<h1>Error ${status}</h1>
-			<p>${error.message}</p>
-			${stack}
-		`);
+
+		// Attempt to render the error page
+		const context = {
+			error: {
+				message: error.message,
+				stack: (showStack ? error.stack : null),
+				status: status
+			}
+		};
+		response.status(status).render('error', context, (renderError, html) => {
+			// If the render fails, build some backup HTML
+			if (renderError) {
+				html = `
+					<h1>Error ${status}</h1>
+					<p>${error.message}</p>
+					${showStack ? `<h2>Error Stack</h2><pre>${error.stack}</pre>` : ''}
+					<hr/>
+					<p>As well as the above error, the application was unable to render an "error" view.</p>
+					${showStack ? `<pre>${renderError.stack}</pre>` : ''}
+				`;
+			}
+			// Output the rendered or backup HTML
+			response.send(html);
+		});
 	}
 
 	// Decide on which handler to use based on

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -3,6 +3,7 @@
 const defaults = require('lodash/defaults');
 const errorHandler = require('./middleware/error-handler');
 const express = require('express');
+const expressHandlebars = require('express-handlebars');
 const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
 const path = require('path');
@@ -12,6 +13,7 @@ module.exports = origamiService;
 
 module.exports.defaults = {
 	basePath: process.cwd(),
+	defaultLayout: false,
 	environment: 'development',
 	log: console,
 	name: 'Origami Service',
@@ -36,7 +38,10 @@ function origamiService(options) {
 	options = defaultOptions(options);
 	const paths = {
 		base: path.join(options.basePath),
-		public: path.join(options.basePath, 'public')
+		public: path.join(options.basePath, 'public'),
+		views: path.join(options.basePath, 'views'),
+		layouts: path.join(options.basePath, 'views/layouts'),
+		partials: path.join(options.basePath, 'views/partials')
 	};
 
 	// Create the Express application
@@ -61,8 +66,9 @@ function origamiService(options) {
 	}));
 
 	// Set up the app.origami property, which we'll use to
-	// store additional info that routes might need
-	app.origami = {
+	// store additional info that routes might need. This
+	// also gets added to locals so is available in views
+	app.origami = app.locals.origami = {
 		log: options.log,
 		options,
 		paths
@@ -87,12 +93,22 @@ function defaultOptions(options) {
 }
 
 // Create and configure an Express application
-function createExpressApp(options) {
+function createExpressApp(options, paths) {
 	const app = express();
 
 	app.set('env', options.environment);
 	app.set('json spaces', 4);
 	app.disable('x-powered-by');
+
+	const handlebars = expressHandlebars.create({
+		defaultLayout: options.defaultLayout,
+		extname: 'html',
+		layoutsDir: paths.layouts,
+		partialsDir: paths.partials
+	});
+	app.engine('html', handlebars.engine);
+	app.set('views', paths.views);
+	app.set('view engine', 'html');
 
 	return app;
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "express": "^4.14.0",
+    "express-handlebars": "^3.0.0",
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
     "morgan": "^1.7.0",

--- a/test/unit/mock/express-handlebars.mock.js
+++ b/test/unit/mock/express-handlebars.mock.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const expressHandlebars = module.exports = {
+	create: sinon.stub()
+};
+const mockInstance = expressHandlebars.mockInstance = {
+	engine: {
+		isMockEngine: true
+	}
+};
+
+expressHandlebars.create.returns(mockInstance);

--- a/test/unit/mock/express.mock.js
+++ b/test/unit/mock/express.mock.js
@@ -6,6 +6,7 @@ const express = module.exports = sinon.stub();
 const mockApp = module.exports.mockApp = {
 	disable: sinon.stub(),
 	enable: sinon.stub(),
+	engine: sinon.stub(),
 	get: sinon.stub(),
 	listen: sinon.stub(),
 	locals: {},
@@ -33,7 +34,7 @@ express.mockResponse = {
 	app: mockApp,
 	locals: {},
 	redirect: sinon.stub().returnsThis(),
-	render: sinon.stub().returnsThis(),
+	render: sinon.stub().returnsThis().yields(),
 	send: sinon.stub().returnsThis(),
 	set: sinon.stub().returnsThis(),
 	status: sinon.stub().returnsThis()


### PR DESCRIPTION
This renders files in the "views" folder with Handlebars, with layout
and partial support. The error handler will also attempt to render an
error template.

Resolves #5