### PR TITLE
Add base path middleware to the built-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ app.use(origamiService.middleware.errorHandler());
 
 The error handling middleware will look for a Handlebars template in `views/error.html` and use it to render the page. If no template is found in that location then it falls back to basic HTML output. This allows you to style your error pages and use your application's default layout.
 
+### `origamiService.middleware.getBasePath()`
+
+Calculate the base path that the application is running on and provide it for use in later middleware and templates. This middleware reads and normalises the `FT-Origami-Service-Base-Path` header (which should be set by the CDN) and adds it to:
+
+  - `request.basePath`: for later middleware to use
+  - `response.locals.basePath`: for templates to use
+
+```js
+app.use(origamiService.middleware.getBasePath());
+// routes go here
+```
+
 ### Examples
 
 You can find example implementations of Origami-compliant services in the `examples` folder of this repo:

--- a/lib/middleware/get-base-path.js
+++ b/lib/middleware/get-base-path.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = getBasePath;
+
+function getBasePath() {
+	return (request, response, next) => {
+		let basePath = request.headers['ft-origami-service-base-path'] || '/';
+		if (!basePath.startsWith('/')) {
+			basePath = `/${basePath}`;
+		}
+		if (!basePath.endsWith('/')) {
+			basePath = `${basePath}/`;
+		}
+		request.basePath = response.locals.basePath = basePath;
+		next();
+	};
+}

--- a/test/unit/lib/middleware/get-base-path.js
+++ b/test/unit/lib/middleware/get-base-path.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('lib/middleware/get-base-path', () => {
+	let express;
+	let getBasePath;
+
+	beforeEach(() => {
+		express = require('../../mock/express.mock');
+		getBasePath = require('../../../../lib/middleware/get-base-path');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(getBasePath);
+	});
+
+	describe('getBasePath()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = getBasePath();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets `request.basePath` to "/"', () => {
+				assert.strictEqual(express.mockRequest.basePath, '/');
+			});
+
+			it('sets `response.locals.basePath` to "/"', () => {
+				assert.strictEqual(express.mockResponse.locals.basePath, '/');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+			describe('when the request has an `FT-Origami-Service-Base-Path` header', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.headers['ft-origami-service-base-path'] = '/foo/bar/';
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sets `request.basePath` to the header value', () => {
+					assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+				});
+
+				it('sets `response.locals.basePath` to the header value', () => {
+					assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+			});
+
+			describe('when the `FT-Origami-Service-Base-Path` header does not begin or end with a slash', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.headers['ft-origami-service-base-path'] = 'foo/bar';
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('sets `request.basePath` to the header value with slashes added', () => {
+					assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+				});
+
+				it('sets `response.locals.basePath` to the header value with slashes added', () => {
+					assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+				});
+
+				it('calls `next` with no error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This middleware is copied across from the Image, Navigation, and Build
services which all rely on it. Currently it's copy/pasted, and it'd be
good to get rid of this duplication by including it here.