### PR TITLE
Add in some cache-control middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ app.use(origamiService.middleware.getBasePath());
 // routes go here
 ```
 
+### `origamiService.middleware.cacheControl( options )`
+
+Add a `Cache-Control` header to the response, including `stale-if-error` and `stale-while-revalidate` directives. The available options are:
+
+  - `maxAge`: The max age to set in the `Cache-Control` header. Must be a valid string that [the ms library can parse](ms-examples). Required
+  - `staleIfError`: Override the `stale-if-error` directive. Must be a valid string that [the ms library can parse](ms-examples). Defaults to the same value as `maxAge`
+  - `staleWhileRevalidate`: Override the `stale-while-revalidate` directive. Must be a valid string that [the ms library can parse](ms-examples). Defaults to the same value as `maxAge`
+
+This middleware is best used per-route, rather than at the application level:
+
+```js
+app.get('/docs', cacheControl({maxAge: '1 day'}), () => {
+    // route stuff
+});
+```
+
 ### Examples
 
 You can find example implementations of Origami-compliant services in the `examples` folder of this repo:
@@ -197,6 +213,7 @@ This software is published by the Financial Times under the [MIT licence][licens
 [issues]: https://github.com/Financial-Times/origami-service/issues
 [license]: http://opensource.org/licenses/MIT
 [morgan]: https://github.com/expressjs/morgan
+[ms-examples]: https://github.com/zeit/ms#examples
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [origami support]: mailto:origami-support@ft.com

--- a/lib/middleware/cache-control.js
+++ b/lib/middleware/cache-control.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const ms = require('ms');
+
+module.exports = cacheControl;
+
+function cacheControl(options) {
+	const cacheControlHeader = getCacheDirectives(options).join(', ');
+	return (request, response, next) => {
+		response.set('Cache-Control', cacheControlHeader);
+		next();
+	};
+}
+
+function getCacheDirectives(options) {
+	options = processOptions(options);
+	const directives = [
+		`max-age=${options.maxAge}`
+	];
+	if (options.maxAge === 0) {
+		return directives.concat([
+			'must-revalidate',
+			'no-cache',
+			'no-store'
+		]);
+	}
+	directives.push('public');
+	if (options.staleIfError) {
+		directives.push(`stale-if-error=${options.staleIfError}`);
+	}
+	if (options.staleWhileRevalidate) {
+		directives.push(`stale-while-revalidate=${options.staleWhileRevalidate}`);
+	}
+	return directives;
+}
+
+function processOptions(options) {
+	options.maxAge = (options.maxAge ? ms(options.maxAge) / 1000 : 0);
+	if (options.staleIfError || options.staleIfError === undefined) {
+		options.staleIfError = (options.staleIfError ? ms(options.staleIfError) / 1000 : options.maxAge);
+	}
+	if (options.staleWhileRevalidate || options.staleWhileRevalidate === undefined) {
+		options.staleWhileRevalidate = (options.staleWhileRevalidate ? ms(options.staleWhileRevalidate) / 1000 : options.maxAge);
+	}
+	return options;
+}

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const cacheControl = require('./middleware/cache-control');
 const defaults = require('lodash/defaults');
 const errorHandler = require('./middleware/error-handler');
 const express = require('express');
 const expressHandlebars = require('express-handlebars');
+const getBasePath = require('./middleware/get-base-path');
 const morgan = require('morgan');
 const notFound = require('./middleware/not-found');
 const path = require('path');
@@ -26,7 +28,9 @@ module.exports.defaults = {
 
 // Middleware exports
 module.exports.middleware = {
+	cacheControl,
 	errorHandler,
+	getBasePath,
 	notFound
 };
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
     "morgan": "^1.7.0",
+    "ms": "^0.7.2",
     "raven": "^1.1.1"
   },
   "devDependencies": {

--- a/test/unit/lib/middleware/cache-control.js
+++ b/test/unit/lib/middleware/cache-control.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/cache-control', () => {
+	let cacheControl;
+	let express;
+	let ms;
+
+	beforeEach(() => {
+		express = require('../../mock/express.mock');
+
+		ms = require('../../mock/ms.mock');
+		mockery.registerMock('ms', ms);
+
+		ms.withArgs('1 hour').returns(3600000);
+		ms.withArgs('1 day').returns(86400000);
+
+		cacheControl = require('../../../../lib/middleware/cache-control');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(cacheControl);
+	});
+
+	describe('cacheControl(options)', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = cacheControl({
+				maxAge: '1 hour'
+			});
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('calls `ms` with `options.maxAge`', () => {
+				assert.calledOnce(ms);
+				assert.calledWithExactly(ms, '1 hour');
+			});
+
+			it('sets the `Cache-Control` header to the return of the `ms` call divided by 1000', () => {
+				assert.calledOnce(express.mockResponse.set);
+				assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=3600, public, stale-if-error=3600, stale-while-revalidate=3600');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+			describe('when `options.maxAge` is falsy', () => {
+
+				beforeEach(() => {
+					express.mockResponse.set.reset();
+					middleware = cacheControl({
+						maxAge: null
+					});
+				});
+
+				describe('middleware(request, response, next)', () => {
+
+					beforeEach(() => {
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('sets the `Cache-Control` header to not cache', () => {
+						assert.calledOnce(express.mockResponse.set);
+						assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
+					});
+
+				});
+
+			});
+
+			describe('when `options.staleIfError` is set', () => {
+
+				beforeEach(() => {
+					ms.reset();
+					express.mockResponse.set.reset();
+					middleware = cacheControl({
+						maxAge: '1 hour',
+						staleIfError: '1 day'
+					});
+				});
+
+				describe('middleware(request, response, next)', () => {
+
+					beforeEach(() => {
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('calls `ms` with `options.maxAge` and `options.staleIfError`', () => {
+						assert.calledTwice(ms);
+						assert.calledWithExactly(ms, '1 hour');
+						assert.calledWithExactly(ms, '1 day');
+					});
+
+					it('sets the `Cache-Control` header to have a different `stale-if-error` directive', () => {
+						assert.calledOnce(express.mockResponse.set);
+						assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=3600, public, stale-if-error=86400, stale-while-revalidate=3600');
+					});
+
+				});
+
+			});
+
+			describe('when `options.staleIfError` is set to a falsy value but not undefined', () => {
+
+				beforeEach(() => {
+					ms.reset();
+					express.mockResponse.set.reset();
+					middleware = cacheControl({
+						maxAge: '1 hour',
+						staleIfError: null
+					});
+				});
+
+				describe('middleware(request, response, next)', () => {
+
+					beforeEach(() => {
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('calls `ms` with `options.maxAge` only', () => {
+						assert.calledOnce(ms);
+						assert.calledWithExactly(ms, '1 hour');
+					});
+
+					it('sets the `Cache-Control` header to have no `stale-if-error` directive', () => {
+						assert.calledOnce(express.mockResponse.set);
+						assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=3600, public, stale-while-revalidate=3600');
+					});
+
+				});
+
+			});
+
+			describe('when `options.staleWhileRevalidate` is set', () => {
+
+				beforeEach(() => {
+					ms.reset();
+					express.mockResponse.set.reset();
+					middleware = cacheControl({
+						maxAge: '1 hour',
+						staleWhileRevalidate: '1 day'
+					});
+				});
+
+				describe('middleware(request, response, next)', () => {
+
+					beforeEach(() => {
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('calls `ms` with `options.maxAge` and `options.staleWhileRevalidate`', () => {
+						assert.calledTwice(ms);
+						assert.calledWithExactly(ms, '1 hour');
+						assert.calledWithExactly(ms, '1 day');
+					});
+
+					it('sets the `Cache-Control` header to have a different `stale-while-revalidate` directive', () => {
+						assert.calledOnce(express.mockResponse.set);
+						assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=3600, public, stale-if-error=3600, stale-while-revalidate=86400');
+					});
+
+				});
+
+			});
+
+			describe('when `options.staleWhileRevalidate` is set to a falsy value but not undefined', () => {
+
+				beforeEach(() => {
+					ms.reset();
+					express.mockResponse.set.reset();
+					middleware = cacheControl({
+						maxAge: '1 hour',
+						staleWhileRevalidate: null
+					});
+				});
+
+				describe('middleware(request, response, next)', () => {
+
+					beforeEach(() => {
+						middleware(express.mockRequest, express.mockResponse, next);
+					});
+
+					it('calls `ms` with `options.maxAge` only', () => {
+						assert.calledOnce(ms);
+						assert.calledWithExactly(ms, '1 hour');
+					});
+
+					it('sets the `Cache-Control` header to have no `stale-while-revalidate` directive', () => {
+						assert.calledOnce(express.mockResponse.set);
+						assert.calledWithExactly(express.mockResponse.set, 'Cache-Control', 'max-age=3600, public, stale-if-error=3600');
+					});
+
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -5,10 +5,12 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 
 describe('lib/origami-service', () => {
+	let cacheControl;
 	let defaults;
 	let errorHandler;
 	let express;
 	let expressHandlebars;
+	let getBasePath;
 	let log;
 	let morgan;
 	let notFound;
@@ -16,6 +18,9 @@ describe('lib/origami-service', () => {
 	let raven;
 
 	beforeEach(() => {
+		cacheControl = sinon.stub();
+		mockery.registerMock('./middleware/cache-control', cacheControl);
+
 		defaults = sinon.spy(require('lodash/defaults'));
 		mockery.registerMock('lodash/defaults', defaults);
 
@@ -27,6 +32,9 @@ describe('lib/origami-service', () => {
 
 		expressHandlebars = require('../mock/express-handlebars.mock');
 		mockery.registerMock('express-handlebars', expressHandlebars);
+
+		getBasePath = sinon.stub();
+		mockery.registerMock('./middleware/get-base-path', getBasePath);
 
 		log = require('../mock/log.mock');
 		mockery.registerMock('log', log);
@@ -101,8 +109,16 @@ describe('lib/origami-service', () => {
 
 	describe('.middleware', () => {
 
+		it('has a `cacheControl` property which references `lib/middleware/cache-control`', () => {
+			assert.strictEqual(origamiService.middleware.cacheControl, cacheControl);
+		});
+
 		it('has an `errorHandler` property which references `lib/middleware/error-handler`', () => {
 			assert.strictEqual(origamiService.middleware.errorHandler, errorHandler);
+		});
+
+		it('has a `getBasePath` property which references `lib/middleware/get-base-path`', () => {
+			assert.strictEqual(origamiService.middleware.getBasePath, getBasePath);
 		});
 
 		it('has a `notFound` property which references `lib/middleware/not-found`', () => {

--- a/test/unit/mock/ms.mock.js
+++ b/test/unit/mock/ms.mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = sinon.stub();


### PR DESCRIPTION
I've added this to core because there's not something out there (that I
could find) which has the behaviour we need: defaulting the stale-*
directives to the max-age directive and allowing them to be overridden.