### PR TITLE
Auto-load middleware

### DIFF
--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const cacheControl = require('./middleware/cache-control');
 const defaults = require('lodash/defaults');
-const errorHandler = require('./middleware/error-handler');
 const express = require('express');
 const expressHandlebars = require('express-handlebars');
-const getBasePath = require('./middleware/get-base-path');
 const morgan = require('morgan');
-const notFound = require('./middleware/not-found');
 const path = require('path');
 const raven = require('raven');
+const requireAll = require('require-all');
+const varname = require('varname');
 
 module.exports = origamiService;
 
@@ -27,12 +25,10 @@ module.exports.defaults = {
 };
 
 // Middleware exports
-module.exports.middleware = {
-	cacheControl,
-	errorHandler,
-	getBasePath,
-	notFound
-};
+module.exports.middleware = requireAll({
+	dirname: `${__dirname}/middleware`,
+	map: varname.camelback
+});
 
 // Function to create an Origami Service app
 function origamiService(options) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "lodash": "^4.17.2",
     "morgan": "^1.7.0",
     "ms": "^0.7.2",
-    "raven": "^1.1.1"
+    "raven": "^1.1.1",
+    "require-all": "^2.1.0",
+    "varname": "^2.0.3"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/test/unit/mock/require-all.mock.js
+++ b/test/unit/mock/require-all.mock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const requireAll = module.exports = sinon.stub();
+const mockModules = requireAll.mockModules = {
+	foo: 'bar',
+	bar: 'baz'
+};
+
+requireAll.returns(mockModules);

--- a/test/unit/mock/varname.mock.js
+++ b/test/unit/mock/varname.mock.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	camelback: sinon.spy()
+};


### PR DESCRIPTION
We're now loading middleware using require-all rather than having to
specify each one in the main origami-service code. Now adding middleware
is just a case of creating the new files.