### PR TITLE
Change the API of Origami Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,21 @@ const origamiService = require('@financial-times/origami-service');
 
 ### `origamiService( [options] )`
 
-This function returns a promise which resolves with a new [Express] application. The Express application will be started automatically, and the returned promise will reject if there's an error in startup.
-
-You can configure the created service with [an options object](#options) if you need to override any defaults.
+This function returns a new [Express] application preconfigured to run as an Origami service. You can configure the created service with [an options object](#options) if you need to override any defaults.
 
 ```js
-origamiService({
+const app = origamiService({
     port: 1234
-})
-.then(app => {
-    // do something with the app
-})
-.catch(error => {
-    // handle the error
 });
+```
+
+The application's `listen` function has a different signature to Express, it's wrapped in a promise and uses the `port` option from the constructor:
+
+```js
+const app = origamiService({
+    port: 1234
+});
+app.listen(); // runs on port 1234 and returns a promise
 ```
 
 The Express application will have some additional properties, added by the Origami Service module. These will also be added to `app.locals` so they're available in your views.
@@ -89,7 +90,6 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `region/REGION`: The region to use in logging and reporting for the application. Defaults to `'EU'`
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`
   - `sentryDsn/SENTRY_DSN`: The [Sentry] DSN to send errors to. If set to `null`, errors will not be sent to Sentry. Defaults to `null`. The `SENTRY_DSN` environment variable is aliased as `RAVEN_URL`
-  - `start`: Whether to automatically start the application. Defaults to `true`
 
 ### `origamiService.middleware.notFound( [message] )`
 

--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -5,23 +5,17 @@
 const origamiService = require('../..');
 
 // Create and run an Origami service
-origamiService({
+const app = origamiService({
 	name: 'Origami Service Basic Example',
 	basePath: __dirname
-})
+});
 
-	// When the service starts...
-	.then(app => {
+// Create a route
+app.get('/', (request, response) => {
+	response.render('index');
+});
 
-		// Create a route
-		app.get('/', (request, response) => {
-			response.render('index');
-		});
-
-	})
-
-	// Catch and log any startup errors
-	.catch(error => {
-		console.error(error.message);
-		process.exit(1);
-	});
+// Start the application
+app.listen().catch(() => {
+	process.exit(1);
+});

--- a/example/middleware/index.js
+++ b/example/middleware/index.js
@@ -5,27 +5,21 @@
 const origamiService = require('../..');
 
 // Create and run an Origami service
-origamiService({
+const app = origamiService({
 	name: 'Origami Service Middleware Example',
 	basePath: __dirname
-})
+});
 
-	// When the service starts...
-	.then(app => {
+// Create a route
+app.get('/', (request, response) => {
+	response.render('index');
+});
 
-		// Create a route
-		app.get('/', (request, response) => {
-			response.render('index');
-		});
+// Mount some error handling middleware
+app.use(origamiService.middleware.notFound('The requested page does not exist'));
+app.use(origamiService.middleware.errorHandler());
 
-		// Mount some error handling middleware
-		app.use(origamiService.middleware.notFound('The requested page does not exist'));
-		app.use(origamiService.middleware.errorHandler());
-
-	})
-
-	// Catch and log any startup errors
-	.catch(error => {
-		console.error(error.message);
-		process.exit(1);
-	});
+// Start the application
+app.listen().catch(() => {
+	process.exit(1);
+});

--- a/example/options/index.js
+++ b/example/options/index.js
@@ -6,24 +6,18 @@ const origamiService = require('../..');
 
 // Create and run an Origami service with some
 // overridden options
-origamiService({
+const app = origamiService({
 	name: 'Origami Service Options Example',
 	basePath: __dirname,
 	port: 8765
-})
+});
 
-	// When the service starts...
-	.then(app => {
+// Create a route
+app.get('/', (request, response) => {
+	response.render('index');
+});
 
-		// Create a route
-		app.get('/', (request, response) => {
-			response.render('index');
-		});
-
-	})
-
-	// Catch and log any startup errors
-	.catch(error => {
-		console.error(error.message);
-		process.exit(1);
-	});
+// Start the application
+app.listen().catch(() => {
+	process.exit(1);
+});

--- a/example/views/index.js
+++ b/example/views/index.js
@@ -6,30 +6,24 @@ const origamiService = require('../..');
 
 // Create and run an Origami service with some
 // overridden options
-origamiService({
+const app = origamiService({
 	name: 'Origami Service Views Example',
 	basePath: __dirname,
 	defaultLayout: 'main'
-})
+});
 
-	// When the service starts...
-	.then(app => {
-
-		// Create a route
-		app.get('/', (request, response) => {
-			response.render('index', {
-				message: 'This text is in the route.'
-			});
-		});
-
-		// Mount some error handling middleware
-		app.use(origamiService.middleware.notFound('The requested page does not exist'));
-		app.use(origamiService.middleware.errorHandler());
-
-	})
-
-	// Catch and log any startup errors
-	.catch(error => {
-		console.error(error.message);
-		process.exit(1);
+// Create a route
+app.get('/', (request, response) => {
+	response.render('index', {
+		message: 'This text is in the route.'
 	});
+});
+
+// Mount some error handling middleware
+app.use(origamiService.middleware.notFound('The requested page does not exist'));
+app.use(origamiService.middleware.errorHandler());
+
+// Start the application
+app.listen().catch(() => {
+	process.exit(1);
+});

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -20,8 +20,7 @@ module.exports.defaults = {
 	port: 8080,
 	region: 'EU',
 	requestLogFormat: 'combined',
-	sentryDsn: null,
-	start: true
+	sentryDsn: null
 };
 
 // Middleware exports
@@ -74,11 +73,11 @@ function origamiService(options) {
 		paths
 	};
 
-	// Return the start promise
-	if (options.start) {
-		return promiseToStart(app);
-	}
-	return Promise.resolve(app);
+	// Promisify app.listen
+	app._originalListen = app.listen;
+	app.listen = listen.bind(null, app);
+
+	return app;
 }
 
 // Default the application options
@@ -121,11 +120,11 @@ function requestLogSkip(request) {
 }
 
 // Promisify the starting of an Express app
-function promiseToStart(app) {
+function listen(app) {
 	return new Promise((resolve, reject) => {
 		const log = app.origami.log;
 		const options = app.origami.options;
-		app.origami.server = app.listen(options.port, error => {
+		app.origami.server = app._originalListen(options.port, error => {
 			if (error) {
 				log.error(`${options.name} startup error (${error.message})`);
 				return reject(error);


### PR DESCRIPTION
The API for Origami Service wasn't very Express-like, and would have
caused more issues migrating from n-express and regular Express. This
updates and simplifies the API.

Resolves #17