### PR TITLE
Allow explicit setting of metrics app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `graphiteApiKey/GRAPHITE_API_KEY`: The API key to use when accessing the FT's internal Graphite instance. If set to `null`, metrics will not be reported. Defaults to `null`. The `GRAPHITE_API_KEY` environment variable is aliased as `FT_GRAPHITE_APIKEY`
   - `healthCheck`: A function to use in calculating how healthy the application is. See [Express Web Service] for more information
   - `log`: A console object used to output non-request logs. Defaults to the global `console` object
+  - `metricsAppName`: The name of the application to use when logging to Graphite. Defaults to `about.systemCode` then `about.name`
   - `port/PORT`: The port that the application should run on. Defaults to `8080`.
   - `region/REGION`: The region to use in logging and reporting for the application. Defaults to `'EU'`
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -66,7 +66,7 @@ function origamiService(options) {
 	if (options.graphiteApiKey) {
 		metrics = new Metrics();
 		metrics.init({
-			app: options.about.systemCode || options.about.name,
+			app: options.metricsAppName || options.about.systemCode || options.about.name,
 			flushEvery: 40000,
 			ftApiKey: options.graphiteApiKey,
 			hostedApiKey: false

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -151,6 +151,7 @@ describe('lib/origami-service', () => {
 				graphiteApiKey: 'mock-graphite-api-key',
 				healthCheck: sinon.spy(),
 				log: log,
+				metricsAppName: 'mock-metrics-app-name',
 				port: 1234,
 				region: 'US',
 				requestLogFormat: 'mock-log-format',
@@ -217,7 +218,7 @@ describe('lib/origami-service', () => {
 			assert.calledOnce(nextMetrics.Metrics);
 			assert.calledOnce(nextMetrics.mockInstance.init);
 			assert.calledWith(nextMetrics.mockInstance.init, {
-				app: options.about.systemCode,
+				app: options.metricsAppName,
 				flushEvery: 40000,
 				ftApiKey: options.graphiteApiKey,
 				hostedApiKey: false
@@ -413,9 +414,25 @@ describe('lib/origami-service', () => {
 
 		});
 
-		describe('when `options.about.systemCode` is not set', () => {
+		describe('when `options.metricsAppName` is not set', () => {
 
 			beforeEach(() => {
+				delete options.metricsAppName;
+				nextMetrics.mockInstance.init.reset();
+				app = origamiService(options);
+			});
+
+			it('uses `options.about.systemCode` as the app name in Next Metrics', () => {
+				assert.calledOnce(nextMetrics.mockInstance.init);
+				assert.strictEqual(nextMetrics.mockInstance.init.firstCall.args[0].app, options.about.systemCode);
+			});
+
+		});
+
+		describe('when `options.metricsAppName` and `options.about.systemCode` are not set', () => {
+
+			beforeEach(() => {
+				delete options.metricsAppName;
 				delete options.about.systemCode;
 				nextMetrics.mockInstance.init.reset();
 				app = origamiService(options);


### PR DESCRIPTION
We need this for the Image Service so that we don't lose historic
data. For the other services we should be able to use the system code.