### PR TITLE
Add warnings for bad configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `defaultLayout`: The default layout file to use in view rendering. This should be the name of an HTML file in the `views/layouts` directory, e.g. `'main'` would map to `views/layouts/main.html`. Defaults to `false`
   - `environment/NODE_ENV`: The environment to run in. This affects things like public file max ages. One of `'production'`, `'development'`, or `'test'`. Defaults to `'development'`
   - `goodToGoTest`: A function to use in calculating whether the application is good to go. See [Express Web Service] for more information
-  - `graphiteApiKey/GRAPHITE_API_KEY`: The API key to use when accessing the FT's internal Graphite instance. If set to `null`, metrics will not be reported. Defaults to `null`. The `GRAPHITE_API_KEY` environment variable is aliased as `FT_GRAPHITE_APIKEY`
+  - `graphiteApiKey/GRAPHITE_API_KEY`: The API key to use when accessing the FT's internal Graphite instance. If set to `null`, metrics will not be reported. Defaults to `null`. The `GRAPHITE_API_KEY` environment variable is aliased as `FT_GRAPHITE_APIKEY` but this is deprecated
   - `healthCheck`: A function to use in calculating how healthy the application is. See [Express Web Service] for more information
   - `log`: A console object used to output non-request logs. Defaults to the global `console` object
   - `metricsAppName`: The name of the application to use when logging to Graphite. Defaults to `about.systemCode` then `about.name`
   - `port/PORT`: The port that the application should run on. Defaults to `8080`.
   - `region/REGION`: The region to use in logging and reporting for the application. Defaults to `'EU'`
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`
-  - `sentryDsn/SENTRY_DSN`: The [Sentry] DSN to send errors to. If set to `null`, errors will not be sent to Sentry. Defaults to `null`. The `SENTRY_DSN` environment variable is aliased as `RAVEN_URL`
+  - `sentryDsn/SENTRY_DSN`: The [Sentry] DSN to send errors to. If set to `null`, errors will not be sent to Sentry. Defaults to `null`. The `SENTRY_DSN` environment variable is aliased as `RAVEN_URL` but this is deprecated
 
 ### `origamiService.middleware.notFound( [message] )`
 

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -48,6 +48,14 @@ function origamiService(options) {
 		partials: path.join(options.basePath, 'views/partials')
 	};
 
+	// Handle deprecation warnings
+	if (process.env.FT_GRAPHITE_APIKEY && !process.env.GRAPHITE_API_KEY) {
+		options.log.warn('Warning: the FT_GRAPHITE_APIKEY environment variable has been deprecated. Use GRAPHITE_API_KEY instead');
+	}
+	if (process.env.RAVEN_URL && !process.env.SENTRY_DSN) {
+		options.log.warn('Warning: the RAVEN_URL environment variable has been deprecated. Use SENTRY_DSN instead');
+	}
+
 	// Load the application manifest and use it
 	// to default some more options
 	let manifest = {};
@@ -82,12 +90,16 @@ function origamiService(options) {
 			});
 			next();
 		});
+	} else {
+		options.log.warn('Warning: metrics are not being recorded for this application. Please provide a GRAPHITE_API_KEY environment variable');
 	}
 
 	// Set up Raven/Sentry request middleware
 	if (options.sentryDsn) {
 		raven.config(options.sentryDsn).install();
 		app.use(raven.requestHandler());
+	} else {
+		options.log.warn('Warning: errors are not being logged to Sentry for this application. Please provide a SENTRY_DSN environment variable');
 	}
 
 	// Set up Express Web Service to provide the

--- a/test/example/run.js
+++ b/test/example/run.js
@@ -40,6 +40,10 @@ describe('examples', () => {
 				});
 
 				example.stderr.on('data', chunk => {
+					// allow warnings
+					if (/^warning:/i.test(chunk.toString())) {
+						return;
+					}
 					clearTimeout(timeout);
 					example.kill('SIGKILL');
 					const error = new Error(`example output to stderr: ${chunk.toString()}`);

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -476,6 +476,11 @@ describe('lib/origami-service', () => {
 				assert.notCalled(nextMetrics.mockInstance.init);
 			});
 
+			it('warns that metrics are not set up', () => {
+				assert.called(options.log.warn);
+				assert.calledWith(options.log.warn, 'Warning: metrics are not being recorded for this application. Please provide a GRAPHITE_API_KEY environment variable');
+			});
+
 		});
 
 		describe('when `options.requestLogFormat` is set to `null`', () => {
@@ -506,6 +511,11 @@ describe('lib/origami-service', () => {
 				assert.deepEqual(defaults.firstCall.args[2].sentryDsn, process.env.RAVEN_URL);
 			});
 
+			it('warns that a deprecated environment variable is being used', () => {
+				assert.called(options.log.warn);
+				assert.calledWith(options.log.warn, 'Warning: the RAVEN_URL environment variable has been deprecated. Use SENTRY_DSN instead');
+			});
+
 		});
 
 		describe('when the `FT_GRAPHITE_APIKEY` environment variable is set and `GRAPHITE_API_KEY` is not', () => {
@@ -518,6 +528,11 @@ describe('lib/origami-service', () => {
 
 			it('uses `FT_GRAPHITE_APIKEY` as a provider for the `graphiteApiKey` option', () => {
 				assert.deepEqual(defaults.firstCall.args[2].graphiteApiKey, process.env.FT_GRAPHITE_APIKEY);
+			});
+
+			it('warns that a deprecated environment variable is being used', () => {
+				assert.called(options.log.warn);
+				assert.calledWith(options.log.warn, 'Warning: the FT_GRAPHITE_APIKEY environment variable has been deprecated. Use GRAPHITE_API_KEY instead');
 			});
 
 		});
@@ -540,9 +555,14 @@ describe('lib/origami-service', () => {
 				assert.notCalled(raven.install);
 			});
 
-			it('creates and mounts Raven request handler middleware', () => {
+			it('does not create and mount Raven request handler middleware', () => {
 				assert.notCalled(raven.requestHandler);
 				assert.neverCalledWith(express.mockApp.use, raven.mockRequestMiddleware);
+			});
+
+			it('warns that Sentry is not set up', () => {
+				assert.called(options.log.warn);
+				assert.calledWith(options.log.warn, 'Warning: errors are not being logged to Sentry for this application. Please provide a SENTRY_DSN environment variable');
 			});
 
 		});


### PR DESCRIPTION
Warnings are now logged when key configurations are not set. We require
that a lot of these are set in production apps, and it's good to remind
developers if they're missing something.

I've also noted that the old n-express environment variables are
deprecated, we'll be removing them in the next major version.

See #40