### PR TITLE
Log more error details

### DIFF
--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cacheControl = require('./cache-control');
+const querystring = require('querystring');
 const raven = require('raven');
 
 module.exports = errorHandler;
@@ -18,13 +19,18 @@ function errorHandler() {
 
 		// Log server errors
 		if (status >= 500) {
-			let singleLineStack = null;
+			const errorMessage = JSON.stringify(error.message);
+			const errorStatus = JSON.stringify(status);
+			const errorUrl = JSON.stringify(request.url);
+			let errorStack;
+
+			// Build error stack
 			if (error.stack) {
 				// Error stacks are multi-line strings which are
 				// padded with whitespace to indent them. We need to
 				// remove this whitespace and escape newlines so
 				// that Splunk registers only one event per error
-				singleLineStack = error.stack
+				errorStack = error.stack
 					// Split into lines
 					.split('\n')
 					// Remove the leading whitespace
@@ -37,9 +43,15 @@ function errorHandler() {
 					.join('\n');
 				// Using JSON stringify adds quotes around the string
 				// and escapes any quotes or newlines within it
-				singleLineStack = JSON.stringify(singleLineStack);
+				errorStack = JSON.stringify(errorStack);
 			}
-			origami.log.error(`Error: ${error.message} stack=${singleLineStack}`);
+			const errorDetail = decodeURIComponent(querystring.stringify({
+				message: errorMessage,
+				status: errorStatus,
+				stack: errorStack || 'null', // null has to be a string here
+				url: errorUrl
+			}, ' '));
+			origami.log.error(`Server Error ${errorDetail}`);
 		}
 
 		// Attempt to render the error page

--- a/test/unit/lib/middleware/error-handler.js
+++ b/test/unit/lib/middleware/error-handler.js
@@ -47,6 +47,7 @@ describe('lib/middleware/error-handler', () => {
 			let next;
 
 			beforeEach(() => {
+				express.mockRequest.url = 'mock-url';
 				express.mockRequest.app.origami = {
 					log,
 					options: {
@@ -71,7 +72,7 @@ describe('lib/middleware/error-handler', () => {
 
 			it('logs the error and escaped error stack', () => {
 				assert.calledOnce(log.error);
-				assert.match(log.error.firstCall.args[0], /^Error: Oops stack="[^"\n]+"$/);
+				assert.match(log.error.firstCall.args[0], /^Server Error message="Oops" status=500 stack="[^"\n]+" url="mock-url"$/);
 			});
 
 			it('creates a cacheControl middleware', () => {
@@ -196,13 +197,14 @@ describe('lib/middleware/error-handler', () => {
 
 				beforeEach(() => {
 					error.status = 499;
+					delete error.stack;
 					log.error.reset();
 					express.mockResponse.render.reset();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
 				it('does not log the error', () => {
-					assert.neverCalledWith(log.error, 'Error: Oops');
+					assert.neverCalledWith(log.error, 'Server Error message="Oops" status=499 stack=null url="mock-url"');
 				});
 
 				it('does not include the stack when rendering the error', () => {
@@ -230,7 +232,7 @@ describe('lib/middleware/error-handler', () => {
 
 				it('logs the error and null error stack', () => {
 					assert.calledOnce(log.error);
-					assert.calledWithExactly(log.error, 'Error: Oops stack=null');
+					assert.calledWithExactly(log.error, 'Server Error message="Oops" status=500 stack=null url="mock-url"');
 				});
 
 			});


### PR DESCRIPTION
The error-handler middleware now logs the error status and URL. This
makes it easier to match up error logs to request logs and debug issues
with services.

Also the error message has been moved into a property which makes it
easier to extract in Splunk.