### PR TITLE
Use a mock metrics instance if an API key isn't set

### DIFF
--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -84,6 +84,9 @@ function origamiService(options) {
 			next();
 		});
 	} else {
+		metrics = {
+			count: function() {}
+		};
 		options.log.warn('Warning: metrics are not being recorded for this application. Please provide a GRAPHITE_API_KEY environment variable');
 	}
 

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -505,6 +505,11 @@ describe('lib/origami-service', () => {
 				assert.notCalled(nextMetrics.mockInstance.init);
 			});
 
+			it('stores a mock instance in `app.origami.metrics`', () => {
+				assert.isObject(express.mockApp.origami.metrics);
+				assert.isFunction(express.mockApp.origami.metrics.count);
+			});
+
 			it('warns that metrics are not set up', () => {
 				assert.called(options.log.warn);
 				assert.calledWith(options.log.warn, 'Warning: metrics are not being recorded for this application. Please provide a GRAPHITE_API_KEY environment variable');


### PR DESCRIPTION
This ensures that the API is the same no matter what, and you don't need
to wrap your metrics calls in a try/catch block.