### PR TITLE
Add middleware for purging URLs from Fastly

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,32 @@ app.get('/docs', origamiService.middleware.cacheControl({maxAge: '1 day'}), () =
 });
 ```
 
+### `origamiService.middleware.purgeUrls( options )`
+
+Create a purge route which will purge all of the given URLs in Fastly when the endpoint is POSTed to. This endpoint accepts general options as well as per-request options in the querystring.
+
+The general options are:
+
+  - `fastlyApiKey/FASTLY_PURGE_API_KEY`: The Fastly API key to use when purging URLs
+  - `purgeApiKey/PURGE_API_KEY`: The API key that is required when a user requests the purge endpoint. If they don't provide this, then the purge will not be performed
+  - `urls`: The URLs that will be purged as an array of strings. This should contain full URLs with a scheme and hostname, that are permitted to be purged with the given Fastly API key
+
+When a user requests the created endpoint, they can use query string parameters to change behaviour:
+
+  - `apiKey`: This is required, and must match the `purgeApiKey` option to work. If this is not provided or is incorrect, an error will be displayed
+  - `wait`: A number of milliseconds to wait before the purge is performed. This can be used to ensure that the purge is performed only once a new version of the application is running. Defaults to `0`
+
+This middleware should be mounted as a route, rather than at the application level:
+
+```js
+app.post('/purge', origamiService.middleware.purgeUrls({
+    urls: [
+        'https://example.com/url-1',
+        'https://example.com/url-2'
+    ]
+}));
+```
+
 ### Examples
 
 You can find example implementations of Origami-compliant services in the `examples` folder of this repo:

--- a/lib/middleware/purge-urls.js
+++ b/lib/middleware/purge-urls.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const defaults = require('lodash/defaults');
+const httpError = require('http-errors');
+const httpRequest = require('request-promise-native');
+
+module.exports = purgeUrls;
+
+module.exports.defaults = {
+	urls: []
+};
+
+function purgeUrls(options) {
+	options = defaultOptions(options);
+
+	// Return a new middleware function
+	return (request, response, next) => {
+		const log = request.app.origami.log;
+
+		// If no API key is provided...
+		if (!request.query.apiKey) {
+			next(httpError(401, 'An apiKey query parameter is required'));
+
+		// If an API key is provided but it is incorrect...
+		} else if (request.query.apiKey !== options.purgeApiKey) {
+			next(httpError(403, 'You do not have permission to purge URLs'));
+
+		// If we have the correct key...
+		} else {
+
+			// Purge all of the URLs (after a timeout)
+			return new Promise(resolve => {
+				setTimeout(resolve, request.query.wait || 0);
+			})
+			.then(() => {
+				return Promise.all(options.urls.map(url => {
+					return httpRequest({
+						uri: url,
+						method: 'PURGE',
+						headers: {
+							'Fastly-Key': options.fastlyApiKey,
+							'Fastly-Soft-Purge': 1
+						},
+						simple: false,
+						resolveWithFullResponse: true
+					})
+					.then(response => {
+						if (response.statusCode < 400) {
+							log.info(`Purged URL from Fastly: ${url}`);
+						} else if (response.statusCode === 401) {
+							throw new Error(`Unable to purge URL from Fastly, permission denied for: ${url}`);
+						} else {
+							throw new Error(`Unable to purge URL from Fastly: ${url}`);
+						}
+					});
+				}));
+			})
+			.then(() => {
+				log.info('Purged URLs successfully');
+				response.send('OK');
+			})
+			.catch(next);
+		}
+
+		// Always return a promise. This is used to ensure testing is consistent
+		return Promise.resolve();
+	};
+}
+
+// Default the middleware options
+function defaultOptions(options) {
+	const environmentOptions = {
+		fastlyApiKey: process.env.FASTLY_PURGE_API_KEY,
+		purgeApiKey: process.env.PURGE_API_KEY
+	};
+	return defaults({}, options, environmentOptions, module.exports.defaults);
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "ms": "^0.7.2",
     "next-metrics": "^1.45.0",
     "raven": "^1.1.1",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4",
     "require-all": "^2.1.0",
     "varname": "^2.0.3"
   },
@@ -42,8 +44,7 @@
     "npm-prepublish": "^1.2.2",
     "nyc": "^10.2.0",
     "proclaim": "^3.4.4",
-    "sinon": "^1.17.6",
-    "sinon-as-promised": "^4.0.2"
+    "sinon": "^2.3.5"
   },
   "nyc": {
     "exclude": [

--- a/test/unit/lib/middleware/cache-control.js
+++ b/test/unit/lib/middleware/cache-control.js
@@ -88,7 +88,7 @@ describe('lib/middleware/cache-control', () => {
 			describe('when `options.staleIfError` is set', () => {
 
 				beforeEach(() => {
-					ms.reset();
+					ms.resetHistory();
 					express.mockResponse.set.reset();
 					middleware = cacheControl({
 						maxAge: '1 hour',
@@ -120,7 +120,7 @@ describe('lib/middleware/cache-control', () => {
 			describe('when `options.staleIfError` is set to a falsy value but not undefined', () => {
 
 				beforeEach(() => {
-					ms.reset();
+					ms.resetHistory();
 					express.mockResponse.set.reset();
 					middleware = cacheControl({
 						maxAge: '1 hour',
@@ -151,7 +151,7 @@ describe('lib/middleware/cache-control', () => {
 			describe('when `options.staleWhileRevalidate` is set', () => {
 
 				beforeEach(() => {
-					ms.reset();
+					ms.resetHistory();
 					express.mockResponse.set.reset();
 					middleware = cacheControl({
 						maxAge: '1 hour',
@@ -183,7 +183,7 @@ describe('lib/middleware/cache-control', () => {
 			describe('when `options.staleWhileRevalidate` is set to a falsy value but not undefined', () => {
 
 				beforeEach(() => {
-					ms.reset();
+					ms.resetHistory();
 					express.mockResponse.set.reset();
 					middleware = cacheControl({
 						maxAge: '1 hour',

--- a/test/unit/lib/middleware/error-handler.js
+++ b/test/unit/lib/middleware/error-handler.js
@@ -113,8 +113,8 @@ describe('lib/middleware/error-handler', () => {
 			describe('when `request.app.origami.options.sentryDsn` is not defined', () => {
 
 				beforeEach(() => {
-					express.mockResponse.status.reset();
-					express.mockResponse.send.reset();
+					express.mockResponse.status.resetHistory();
+					express.mockResponse.send.resetHistory();
 					raven.mockErrorMiddleware.reset();
 					delete express.mockRequest.app.origami.options.sentryDsn;
 					middleware(error, express.mockRequest, express.mockResponse, next);
@@ -152,7 +152,7 @@ describe('lib/middleware/error-handler', () => {
 
 				beforeEach(() => {
 					error.status = 567;
-					express.mockResponse.status.reset();
+					express.mockResponse.status.resetHistory();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -167,7 +167,7 @@ describe('lib/middleware/error-handler', () => {
 
 				beforeEach(() => {
 					error.statusCode = 567;
-					express.mockResponse.status.reset();
+					express.mockResponse.status.resetHistory();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -182,7 +182,7 @@ describe('lib/middleware/error-handler', () => {
 
 				beforeEach(() => {
 					error.status_code = 567;
-					express.mockResponse.status.reset();
+					express.mockResponse.status.resetHistory();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -241,7 +241,7 @@ describe('lib/middleware/error-handler', () => {
 
 				beforeEach(() => {
 					error.cacheMaxAge = '1d';
-					cacheControl.reset();
+					cacheControl.resetHistory();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -261,7 +261,7 @@ describe('lib/middleware/error-handler', () => {
 				beforeEach(() => {
 					renderError = new Error('render-error');
 					express.mockResponse.render.yields(renderError);
-					express.mockResponse.send.reset();
+					express.mockResponse.send.resetHistory();
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -278,7 +278,7 @@ describe('lib/middleware/error-handler', () => {
 
 					beforeEach(() => {
 						error.status = 400;
-						express.mockResponse.send.reset();
+						express.mockResponse.send.resetHistory();
 						middleware(error, express.mockRequest, express.mockResponse, next);
 					});
 

--- a/test/unit/lib/middleware/purge-urls.js
+++ b/test/unit/lib/middleware/purge-urls.js
@@ -1,0 +1,281 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/purge-urls', () => {
+	let defaults;
+	let express;
+	let httpError;
+	let httpRequest;
+	let log;
+	let purgeUrls;
+
+	beforeEach(() => {
+		defaults = sinon.spy(require('lodash/defaults'));
+		mockery.registerMock('lodash/defaults', defaults);
+
+		express = require('../../mock/express.mock');
+
+		httpError = require('../../mock/http-errors.mock');
+		mockery.registerMock('http-errors', httpError);
+
+		httpRequest = require('../../mock/request-promise-native.mock');
+		mockery.registerMock('request-promise-native', httpRequest);
+
+		log = require('../../mock/log.mock');
+
+		purgeUrls = require('../../../../lib/middleware/purge-urls');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(purgeUrls);
+	});
+
+	it('has a `defaults` property', () => {
+		assert.isObject(purgeUrls.defaults);
+	});
+
+	describe('.defaults', () => {
+
+		it('has a `urls` property', () => {
+			assert.isArray(purgeUrls.defaults.urls);
+			assert.deepEqual(purgeUrls.defaults.urls, []);
+		});
+
+	});
+
+	describe('purgeUrls(options)', () => {
+		let options;
+		let middleware;
+
+		beforeEach(() => {
+
+			// Define options in the environment and
+			// as an object (which takes priority)
+			process.env.FASTLY_PURGE_API_KEY = 'env-fastly-key';
+			process.env.PURGE_API_KEY = 'env-purge-key';
+			options = {
+				fastlyApiKey: 'mock-fastly-key',
+				purgeApiKey: 'mock-purge-key',
+				urls: [
+					'https://mock-url/1',
+					'https://mock-url/2',
+					'https://mock-url/3'
+				]
+			};
+
+			middleware = purgeUrls(options);
+		});
+
+		it('defaults the passed in options', () => {
+			assert.isObject(defaults.firstCall.args[0]);
+			assert.strictEqual(defaults.firstCall.args[1], options);
+			assert.deepEqual(defaults.firstCall.args[2], {
+				fastlyApiKey: process.env.FASTLY_PURGE_API_KEY,
+				purgeApiKey: process.env.PURGE_API_KEY
+			});
+			assert.strictEqual(defaults.firstCall.args[3], purgeUrls.defaults);
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+			let mockHttpResponse;
+
+			beforeEach(() => {
+				mockHttpResponse = {
+					statusCode: 200
+				};
+				httpRequest.resolves(mockHttpResponse);
+				express.mockRequest.query.apiKey = 'mock-purge-key';
+				express.mockApp.origami = {log};
+				next = sinon.spy();
+				return middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('makes a PURGE request for each URL', () => {
+				assert.calledThrice(httpRequest);
+
+				assert.deepEqual(httpRequest.firstCall.args[0], {
+					uri: 'https://mock-url/1',
+					method: 'PURGE',
+					headers: {
+						'Fastly-Key': 'mock-fastly-key',
+						'Fastly-Soft-Purge': 1
+					},
+					simple: false,
+					resolveWithFullResponse: true
+				});
+
+				assert.deepEqual(httpRequest.secondCall.args[0], {
+					uri: 'https://mock-url/2',
+					method: 'PURGE',
+					headers: {
+						'Fastly-Key': 'mock-fastly-key',
+						'Fastly-Soft-Purge': 1
+					},
+					simple: false,
+					resolveWithFullResponse: true
+				});
+
+				assert.deepEqual(httpRequest.thirdCall.args[0], {
+					uri: 'https://mock-url/3',
+					method: 'PURGE',
+					headers: {
+						'Fastly-Key': 'mock-fastly-key',
+						'Fastly-Soft-Purge': 1
+					},
+					simple: false,
+					resolveWithFullResponse: true
+				});
+			});
+
+			it('logs that each URL has been purged', () => {
+				assert.calledWithExactly(log.info, 'Purged URL from Fastly: https://mock-url/1');
+				assert.calledWithExactly(log.info, 'Purged URL from Fastly: https://mock-url/2');
+				assert.calledWithExactly(log.info, 'Purged URL from Fastly: https://mock-url/3');
+				assert.calledWithExactly(log.info, 'Purged URLs successfully');
+			});
+
+			it('responds with "OK"', () => {
+				assert.calledOnce(express.mockResponse.send);
+				assert.calledWithExactly(express.mockResponse.send, 'OK');
+			});
+
+			it('does not call `next`', () => {
+				assert.notCalled(next);
+			});
+
+			describe('when `request` has a `wait` query parameter', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					express.mockRequest.query.wait = '1000';
+					sinon.stub(global, 'setTimeout').yieldsAsync();
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				afterEach(() => {
+					global.setTimeout.restore();
+				});
+
+				it('sets a timeout before requesting the URLs', () => {
+					assert.calledOnce(setTimeout);
+					assert.strictEqual(setTimeout.firstCall.args[1], express.mockRequest.query.wait);
+				});
+
+			});
+
+			describe('when `request` does not have an `apiKey` query parameter', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					delete express.mockRequest.query.apiKey;
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not respond with "OK"', () => {
+					assert.notCalled(express.mockResponse.send);
+				});
+
+				it('Calls `next` with a new HTTP 401 error', () => {
+					assert.calledOnce(httpError);
+					assert.calledWithExactly(httpError, 401, 'An apiKey query parameter is required');
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, httpError.mockError);
+				});
+
+			});
+
+			describe('when the `request` has an incorrect `apiKey` query parameter', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					express.mockRequest.query.apiKey = 'not-the-key';
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not respond with "OK"', () => {
+					assert.notCalled(express.mockResponse.send);
+				});
+
+				it('Calls `next` with a new HTTP 403 error', () => {
+					assert.calledOnce(httpError);
+					assert.calledWithExactly(httpError, 403, 'You do not have permission to purge URLs');
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, httpError.mockError);
+				});
+
+			});
+
+			describe('when one of the HTTP requests fails', () => {
+				let mockHttpError;
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					mockHttpError = new Error('http error');
+					httpRequest.rejects(mockHttpError);
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not respond with "OK"', () => {
+					assert.notCalled(express.mockResponse.send);
+				});
+
+				it('Calls `next` with the HTTP error', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next, mockHttpError);
+				});
+
+			});
+
+			describe('when one of the HTTP requests responds with a 401 status code', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					mockHttpResponse.statusCode = 401;
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not respond with "OK"', () => {
+					assert.notCalled(express.mockResponse.send);
+				});
+
+				it('Calls `next` with a descriptive error', () => {
+					assert.calledOnce(next);
+					assert.instanceOf(next.firstCall.args[0], Error);
+					assert.match(next.firstCall.args[0].message, /Unable to purge URL from Fastly, permission denied for: https:\/\/mock-url\//i);
+				});
+
+			});
+
+			describe('when one of the HTTP requests responds with an unsuccessful status code', () => {
+
+				beforeEach(() => {
+					express.mockResponse.send.resetHistory();
+					mockHttpResponse.statusCode = 500;
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not respond with "OK"', () => {
+					assert.notCalled(express.mockResponse.send);
+				});
+
+				it('Calls `next` with a generic server error', () => {
+					assert.calledOnce(next);
+					assert.instanceOf(next.firstCall.args[0], Error);
+					assert.match(next.firstCall.args[0].message, /Unable to purge URL from Fastly: https:\/\/mock-url\//i);
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/request-promise-native.mock.js
+++ b/test/unit/mock/request-promise-native.mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = sinon.stub().resolves();

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -3,7 +3,6 @@
 const assert = require('proclaim');
 const mockery = require('mockery');
 const sinon = require('sinon');
-require('sinon-as-promised');
 
 sinon.assert.expose(assert, {
 	includeFail: false,


### PR DESCRIPTION
This middleware allows applications to register a purge endpoint which
can be used to clear their Fastly cache. This is secured with an API key
and caters for applications which use Heroku preboot.