### PR TITLE
Always respond when purging URLs

### DIFF
--- a/lib/middleware/purge-urls.js
+++ b/lib/middleware/purge-urls.js
@@ -28,6 +28,11 @@ function purgeUrls(options) {
 		// If we have the correct key...
 		} else {
 
+			// Respond immediately
+			response
+				.status(202)
+				.send('Purging URLs');
+
 			// Purge all of the URLs (after a timeout)
 			return new Promise(resolve => {
 				const timeout = request.query.wait || 0;
@@ -60,9 +65,10 @@ function purgeUrls(options) {
 			})
 			.then(() => {
 				log.info('Purged URLs successfully');
-				response.send('OK');
 			})
-			.catch(next);
+			.catch(error => {
+				log.error(`Error purging URLs: ${error.message}`);
+			});
 		}
 
 		// Always return a promise. This is used to ensure testing is consistent


### PR DESCRIPTION
We now rely on logs for errors, rather than responses to the user. This
means that we don't hit Heroku response timeouts.