### PR TITLE
Change the `origami` variable to `ft`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,16 @@ Origami Service's API changes between major versions. This is a guide to help yo
 Table Of Contents
 -----------------
 
+  - [Migrating from 2.0 to 3.0](#migrating-from-20-to-30)
   - [Migrating from 1.0 to 2.0](#migrating-from-10-to-20)
+
+
+Migrating from 2.0 to 3.0
+-------------------------
+
+### Properties
+
+Origami Service 3.0 renames the `app.origami` property to `app.ft`. This is also renamed in the views, the global `origami` view variable is named `ft`.
 
 
 Migrating from 1.0 to 2.0

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ app.listen(); // runs on port 1234 and returns a promise
 
 The Express application will have some additional properties, added by the Origami Service module. These will also be added to `app.locals` so they're available in your views.
 
-  - `app.origami.log`: The logger passed in to the service
-  - `app.origami.metrics`: The [Next Metrics] instance which can be used to send additional data to Graphite
-  - `app.origami.options`: The defaulted [options](#options) passed into the `origamiService` call
-  - `app.origami.server`: The [HTTP Server] which was returned by `app.listen`
+  - `app.ft.log`: The logger passed in to the service
+  - `app.ft.metrics`: The [Next Metrics] instance which can be used to send additional data to Graphite
+  - `app.ft.options`: The defaulted [options](#options) passed into the `origamiService` call
+  - `app.ft.server`: The [HTTP Server] which was returned by `app.listen`
 
 The following [Express settings] will be set:
 

--- a/example/basic/views/index.html
+++ b/example/basic/views/index.html
@@ -1,4 +1,4 @@
 
-<h1>{{origami.options.about.name}}</h1>
+<h1>{{ft.options.about.name}}</h1>
 
 <p>Hello World!</p>

--- a/example/middleware/views/index.html
+++ b/example/middleware/views/index.html
@@ -1,4 +1,4 @@
 
-<h1>{{origami.options.about.name}}</h1>
+<h1>{{ft.options.about.name}}</h1>
 
 <p>Hello World!</p>

--- a/example/options/views/index.html
+++ b/example/options/views/index.html
@@ -1,4 +1,4 @@
 
-<h1>{{origami.options.about.name}}</h1>
+<h1>{{ft.options.about.name}}</h1>
 
 <p>Hello World!</p>

--- a/example/views/views/index.html
+++ b/example/views/views/index.html
@@ -1,5 +1,5 @@
 
-<h1>{{origami.options.about.name}}</h1>
+<h1>{{ft.options.about.name}}</h1>
 
 <p>This text is in the view.</p>
 

--- a/example/views/views/layouts/main.html
+++ b/example/views/views/layouts/main.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta charset="utf-8">
-		<title>{{origami.options.about.name}}</title>
+		<title>{{ft.options.about.name}}</title>
 	</head>
 	<body>
 

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -13,9 +13,9 @@ function errorHandler() {
 
 	// Handler for rendering to the user
 	function standardErrorHandler(error, request, response) {
-		const origami = request.app.origami;
+		const ft = request.app.ft;
 		const status = error.status || error.statusCode || error.status_code || 500;
-		const showStack = (status >= 500 && origami.options.environment !== 'production');
+		const showStack = (status >= 500 && ft.options.environment !== 'production');
 
 		// Log server errors
 		if (status >= 500) {
@@ -51,7 +51,7 @@ function errorHandler() {
 				stack: errorStack || 'null', // null has to be a string here
 				url: errorUrl
 			}, ' '));
-			origami.log.error(`Server Error ${errorDetail}`);
+			ft.log.error(`Server Error ${errorDetail}`);
 		}
 
 		// Attempt to render the error page
@@ -91,7 +91,7 @@ function errorHandler() {
 	// Decide on which handler to use based on
 	// whether Sentry has been configured
 	return (error, request, response, next) => {
-		if (request.app.origami.options.sentryDsn) {
+		if (request.app.ft.options.sentryDsn) {
 			return ravenErrorHandler(error, request, response, error => {
 				standardErrorHandler(error, request, response, next);
 			});

--- a/lib/middleware/purge-urls.js
+++ b/lib/middleware/purge-urls.js
@@ -15,7 +15,7 @@ function purgeUrls(options) {
 
 	// Return a new middleware function
 	return (request, response, next) => {
-		const log = request.app.origami.log;
+		const log = request.app.ft.log;
 
 		// If no API key is provided...
 		if (!request.query.apiKey) {

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -137,10 +137,10 @@ function origamiService(options) {
 	}, ' ');
 	options.log.info(`${options.about.name} configured (${optionReport})`);
 
-	// Set up the app.origami property, which we'll use to
+	// Set up the app.ft property, which we'll use to
 	// store additional info that routes might need. This
 	// also gets added to locals so is available in views
-	app.origami = app.locals.origami = {
+	app.ft = app.locals.ft = {
 		log: options.log,
 		metrics,
 		options,
@@ -198,9 +198,9 @@ function requestLogSkip(request) {
 // Promisify the starting of an Express app
 function listen(app) {
 	return new Promise((resolve, reject) => {
-		const log = app.origami.log;
-		const options = app.origami.options;
-		app.origami.server = app._originalListen(options.port, error => {
+		const log = app.ft.log;
+		const options = app.ft.options;
+		app.ft.server = app._originalListen(options.port, error => {
 			if (error) {
 				log.error(`${options.about.name} startup error (${error.message})`);
 				return reject(error);

--- a/test/unit/lib/middleware/error-handler.js
+++ b/test/unit/lib/middleware/error-handler.js
@@ -48,7 +48,7 @@ describe('lib/middleware/error-handler', () => {
 
 			beforeEach(() => {
 				express.mockRequest.url = 'mock-url';
-				express.mockRequest.app.origami = {
+				express.mockRequest.app.ft = {
 					log,
 					options: {
 						sentryDsn: 'mock-sentry-dsn'
@@ -110,13 +110,13 @@ describe('lib/middleware/error-handler', () => {
 				assert.calledWithExactly(express.mockResponse.send, 'mock-html');
 			});
 
-			describe('when `request.app.origami.options.sentryDsn` is not defined', () => {
+			describe('when `request.app.ft.options.sentryDsn` is not defined', () => {
 
 				beforeEach(() => {
 					express.mockResponse.status.resetHistory();
 					express.mockResponse.send.resetHistory();
 					raven.mockErrorMiddleware.reset();
-					delete express.mockRequest.app.origami.options.sentryDsn;
+					delete express.mockRequest.app.ft.options.sentryDsn;
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
@@ -126,11 +126,11 @@ describe('lib/middleware/error-handler', () => {
 
 			});
 
-			describe('when `request.app.origami.options.environment` is "production"', () => {
+			describe('when `request.app.ft.options.environment` is "production"', () => {
 
 				beforeEach(() => {
 					express.mockResponse.render.reset();
-					express.mockRequest.app.origami.options.environment = 'production';
+					express.mockRequest.app.ft.options.environment = 'production';
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 

--- a/test/unit/lib/middleware/purge-urls.js
+++ b/test/unit/lib/middleware/purge-urls.js
@@ -93,7 +93,7 @@ describe('lib/middleware/purge-urls', () => {
 				};
 				httpRequest.resolves(mockHttpResponse);
 				express.mockRequest.query.apiKey = 'mock-purge-key';
-				express.mockApp.origami = {log};
+				express.mockApp.ft = {log};
 				next = sinon.spy();
 				return middleware(express.mockRequest, express.mockResponse, next);
 			});

--- a/test/unit/lib/origami-service.js
+++ b/test/unit/lib/origami-service.js
@@ -322,16 +322,16 @@ describe('lib/origami-service', () => {
 			assert.calledWith(log.info, 'Test App configured (graphite=true logging=true sentry=true)');
 		});
 
-		it('stores additional data in the `app.origami` object', () => {
-			assert.isObject(express.mockApp.origami);
+		it('stores additional data in the `app.ft` object', () => {
+			assert.isObject(express.mockApp.ft);
 		});
 
-		it('stores the defaulted options in `app.origami.options`', () => {
-			assert.strictEqual(express.mockApp.origami.options, defaults.firstCall.returnValue);
+		it('stores the defaulted options in `app.ft.options`', () => {
+			assert.strictEqual(express.mockApp.ft.options, defaults.firstCall.returnValue);
 		});
 
-		it('stores useful application paths in `app.origami.paths`', () => {
-			assert.deepEqual(express.mockApp.origami.paths, {
+		it('stores useful application paths in `app.ft.paths`', () => {
+			assert.deepEqual(express.mockApp.ft.paths, {
 				base: 'mock-base-path',
 				manifest: 'mock-base-path/package.json',
 				public: 'mock-base-path/public',
@@ -341,16 +341,16 @@ describe('lib/origami-service', () => {
 			});
 		});
 
-		it('stores the logger in `app.origami.log`', () => {
-			assert.strictEqual(express.mockApp.origami.log.info, options.log.info);
+		it('stores the logger in `app.ft.log`', () => {
+			assert.strictEqual(express.mockApp.ft.log.info, options.log.info);
 		});
 
-		it('stores the Next Metrics instance in `app.origami.metrics`', () => {
-			assert.strictEqual(express.mockApp.origami.metrics, nextMetrics.mockInstance);
+		it('stores the Next Metrics instance in `app.ft.metrics`', () => {
+			assert.strictEqual(express.mockApp.ft.metrics, nextMetrics.mockInstance);
 		});
 
-		it('stores a copy of `app.origami` in `app.locals.origami`', () => {
-			assert.strictEqual(express.mockApp.origami, express.mockApp.locals.origami);
+		it('stores a copy of `app.ft` in `app.locals.ft`', () => {
+			assert.strictEqual(express.mockApp.ft, express.mockApp.locals.ft);
 		});
 
 		it('returns the created Express application', () => {
@@ -365,7 +365,7 @@ describe('lib/origami-service', () => {
 			});
 
 			it('sets the schema version to 1', () => {
-				assert.strictEqual(app.origami.options.about.schemaVersion, 1);
+				assert.strictEqual(app.ft.options.about.schemaVersion, 1);
 			});
 
 		});
@@ -378,7 +378,7 @@ describe('lib/origami-service', () => {
 			});
 
 			it('sets the name to the manifest name', () => {
-				assert.strictEqual(app.origami.options.about.name, manifest.name);
+				assert.strictEqual(app.ft.options.about.name, manifest.name);
 			});
 
 		});
@@ -392,7 +392,7 @@ describe('lib/origami-service', () => {
 			});
 
 			it('sets the name to a default', () => {
-				assert.strictEqual(app.origami.options.about.name, 'Origami Service');
+				assert.strictEqual(app.ft.options.about.name, 'Origami Service');
 			});
 
 		});
@@ -405,7 +405,7 @@ describe('lib/origami-service', () => {
 			});
 
 			it('sets the purpose to the manifest description', () => {
-				assert.strictEqual(app.origami.options.about.purpose, manifest.description);
+				assert.strictEqual(app.ft.options.about.purpose, manifest.description);
 			});
 
 		});
@@ -419,7 +419,7 @@ describe('lib/origami-service', () => {
 			});
 
 			it('sets the purpose to a default', () => {
-				assert.strictEqual(app.origami.options.about.purpose, 'An Origami web service.');
+				assert.strictEqual(app.ft.options.about.purpose, 'An Origami web service.');
 			});
 
 		});
@@ -505,9 +505,9 @@ describe('lib/origami-service', () => {
 				assert.notCalled(nextMetrics.mockInstance.init);
 			});
 
-			it('stores a mock instance in `app.origami.metrics`', () => {
-				assert.isObject(express.mockApp.origami.metrics);
-				assert.isFunction(express.mockApp.origami.metrics.count);
+			it('stores a mock instance in `app.ft.metrics`', () => {
+				assert.isObject(express.mockApp.ft.metrics);
+				assert.isFunction(express.mockApp.ft.metrics.count);
 			});
 
 			it('warns that metrics are not set up', () => {
@@ -595,8 +595,8 @@ describe('lib/origami-service', () => {
 					assert.strictEqual(resolvedValue, app);
 				});
 
-				it('stores the created server in `app.origami.server`', () => {
-					assert.strictEqual(app.origami.server, express.mockServer);
+				it('stores the created server in `app.ft.server`', () => {
+					assert.strictEqual(app.ft.server, express.mockServer);
 				});
 
 				it('logs that the application has started', () => {


### PR DESCRIPTION
This is more generic, and will stop us from littering other FT services
with "origami".