### PR TITLE
update to express@4.16.0 to fix vulnverable mime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,23 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -270,6 +287,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -753,12 +775,13 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "express": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
-      "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.0.tgz",
+      "integrity": "sha1-tRljjk61jnF4yBtJjvIveYyy4lU=",
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
@@ -768,23 +791,31 @@
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.6",
-        "serve-static": "1.12.6",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.0",
+        "serve-static": "1.13.0",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        }
       }
     },
     "express-handlebars": {
@@ -856,9 +887,9 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.1",
@@ -1096,8 +1127,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.5",
@@ -1154,9 +1184,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -1468,9 +1498,9 @@
       "integrity": "sha1-jQ5H4aiyLEduTDYc5ydAWP+ZsZk="
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -3567,12 +3597,12 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -3587,9 +3617,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -3618,6 +3648,17 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
           "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
         }
+      }
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
       }
     },
     "readable-stream": {
@@ -3801,9 +3842,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.0.tgz",
+      "integrity": "sha1-FjONu5ou3krVe0hCDsO4LY6ApXs=",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
@@ -3813,7 +3854,7 @@
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
@@ -3821,14 +3862,14 @@
       }
     },
     "serve-static": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz",
+      "integrity": "sha1-gQyR24AOlLoofq5rTgbKq5/cFvE=",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.6"
+        "send": "0.16.0"
       }
     },
     "setprototypeof": {
@@ -4183,9 +4224,9 @@
       }
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@financial-times/express-web-service": "^3.3.1",
-    "express": "^4.15.5",
+    "express": "^4.16.0",
     "express-handlebars": "^3.0.0",
     "http-errors": "^1.6.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
```
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:mime:20170907
- from: @financial-times/origami-service@0.0.0 > express@4.15.5 > send@0.15.6 > mime@1.3.4
Upgrade direct dependency express@4.15.5 to express@4.16.0 (triggers upgrades to send@0.16.0 > mime@1.4.1)
```