### PR TITLE
Allow Sentry to be configured fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `port/PORT`: The port that the application should run on. Defaults to `8080`.
   - `region/REGION`: The region to use in logging and reporting for the application. Defaults to `'EU'`
   - `requestLogFormat`: The [Morgan] log format to output request logs in. If set to `null`, request logs will not be output. Defaults to `'combined'`
+  - `sentryConfig`: Additional [Sentry] configurations. This is passed directly to the Raven configuration, [see here for more information][raven-config]. Defaults to `{}`
   - `sentryDsn/SENTRY_DSN`: The [Sentry] DSN to send errors to. If set to `null`, errors will not be sent to Sentry. Defaults to `null`
 
 ### `origamiService.middleware.notFound( [message] )`
@@ -293,5 +294,6 @@ This software is published by the Financial Times under the [MIT licence][licens
 [npm]: https://www.npmjs.com/
 [origami support]: mailto:origami-support@ft.com
 [promises]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[raven-config]: https://docs.sentry.io/clients/node/config/#optional-settings
 [sentry]: https://sentry.io/
 [static]: https://expressjs.com/en/starter/static-files.html

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -25,6 +25,7 @@ module.exports.defaults = {
 	port: 8080,
 	region: 'EU',
 	requestLogFormat: 'combined',
+	sentryConfig: {},
 	sentryDsn: null
 };
 
@@ -93,7 +94,7 @@ function origamiService(options) {
 
 	// Set up Raven/Sentry request middleware
 	if (options.sentryDsn) {
-		raven.config(options.sentryDsn).install();
+		raven.config(options.sentryDsn, options.sentryConfig).install();
 		app.use(raven.requestHandler());
 	} else {
 		options.log.warn('Warning: errors are not being logged to Sentry for this application. Please provide a SENTRY_DSN environment variable');

--- a/test/unit/lib/origami-service.test.js
+++ b/test/unit/lib/origami-service.test.js
@@ -109,6 +109,11 @@ describe('lib/origami-service', () => {
 			assert.strictEqual(origamiService.defaults.requestLogFormat, 'combined');
 		});
 
+		it('has a `sentryConfig` property', () => {
+			assert.isObject(origamiService.defaults.sentryConfig);
+			assert.deepEqual(origamiService.defaults.sentryConfig, {});
+		});
+
 		it('has a `sentryDsn` property', () => {
 			assert.isNull(origamiService.defaults.sentryDsn);
 		});
@@ -159,6 +164,9 @@ describe('lib/origami-service', () => {
 				port: 1234,
 				region: 'US',
 				requestLogFormat: 'mock-log-format',
+				sentryConfig: {
+					isMockSentryConfig: true
+				},
 				sentryDsn: 'mock-sentry-dsn'
 			};
 
@@ -249,7 +257,7 @@ describe('lib/origami-service', () => {
 		it('configures and installs Raven', () => {
 			assert.calledOnce(raven.config);
 			assert.calledOnce(raven.install);
-			assert.calledWithExactly(raven.config, options.sentryDsn);
+			assert.calledWithExactly(raven.config, options.sentryDsn, options.sentryConfig);
 		});
 
 		it('creates and mounts Raven request handler middleware', () => {


### PR DESCRIPTION
This is related to Jake's comment here: https://github.com/Financial-Times/origami-service/pull/59#issuecomment-340404052