### PR TITLE
Allow the error handling middleware to output JSON

### DIFF
--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,12 +1,18 @@
 'use strict';
 
 const cacheControl = require('./cache-control');
+const defaults = require('lodash/defaults');
 const querystring = require('querystring');
 const raven = require('raven');
 
 module.exports = errorHandler;
 
-function errorHandler() {
+module.exports.defaults = {
+	outputJson: false
+};
+
+function errorHandler(options) {
+	options = defaultOptions(options);
 
 	// Handler for sending errors to Sentry
 	const ravenErrorHandler = raven.errorHandler();
@@ -59,7 +65,7 @@ function errorHandler() {
 			title: `Error ${status}`,
 			error: {
 				message: error.message,
-				stack: (showStack ? error.stack : null),
+				stack: (showStack ? error.stack : undefined),
 				status: status
 			}
 		};
@@ -71,7 +77,15 @@ function errorHandler() {
 			staleIfError: 0
 		})(request, response);
 
-		response.status(status).render('error', context, (renderError, html) => {
+		// Set the response status
+		response.status(status);
+
+		// Output JSON if it's requested
+		if (options.outputJson) {
+			return response.send(context.error);
+		}
+
+		response.render('error', context, (renderError, html) => {
 			// If the render fails, build some backup HTML
 			if (renderError) {
 				html = `
@@ -99,4 +113,9 @@ function errorHandler() {
 		standardErrorHandler(error, request, response, next);
 	};
 
+}
+
+// Default the middleware options
+function defaultOptions(options) {
+	return defaults({}, options, module.exports.defaults);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@financial-times/origami-service-makefile": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.0.0.tgz",
-      "integrity": "sha1-Bi/9Hj9jLUR4xgQSZYFOtS/S8oI=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.1.0.tgz",
+      "integrity": "sha1-tLU9qjRqnF6RrX33DZx7DSF0zpU=",
       "dev": true
     },
     "accepts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "varname": "^2.0.3"
   },
   "devDependencies": {
-    "@financial-times/origami-service-makefile": "^6.0.0",
+    "@financial-times/origami-service-makefile": "^6.1.0",
     "eslint": "^4.7.2",
     "mocha": "^3.5.3",
     "mockery": "^2.1.0",


### PR DESCRIPTION
For JSON APIs, this makes more sense than rendering an HTML page, as a
client of that API can easily read and action the message.