### PR TITLE
allow helper config to be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The available options are as follows. Where two names are separated by a `/`, th
   - `about`: About information to populate the `/__about` endpoint with. This should be an object which conforms to the FT's [about/runbook standard][about-standard]. This defaults the `name/purpose` properties to `name/description` from your `package.json` file if they're not set. This option gets passed on to [Express Web Service]
   - `basePath`: The base path of the application, which paths (e.g. public files) will be relative to. Defaults to `process.cwd()`
   - `defaultLayout`: The default layout file to use in view rendering. This should be the name of an HTML file in the `views/layouts` directory, e.g. `'main'` would map to `views/layouts/main.html`. Defaults to `false`
+  - `handlebarsHelpers`: Handlebars helpers configuration. This should be an object. Defaults to an empty object.
   - `exposeErrorEndpoint/EXPOSE_ERROR_ENDPOINT`: Whether to expose the `/__error` endpoint for debugging purposes. This should be `false` in production. Defaults to `false`
   - `environment/NODE_ENV`: The environment to run in. This affects things like public file max ages. One of `'production'`, `'development'`, or `'test'`. Defaults to `'development'`
   - `goodToGoTest`: A function to use in calculating whether the application is good to go. See [Express Web Service] for more information

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -21,6 +21,7 @@ module.exports.defaults = {
 	environment: 'development',
 	exposeErrorEndpoint: false,
 	graphiteApiKey: null,
+	handlebarsHelpers: {},
 	log: console,
 	port: 8080,
 	region: 'EU',

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -47,8 +47,7 @@ function origamiService(options) {
 		public: path.join(options.basePath, 'public'),
 		views: path.join(options.basePath, 'views'),
 		layouts: path.join(options.basePath, 'views/layouts'),
-		partials: path.join(options.basePath, 'views/partials'),
-		helpers: path.join(options.basePath, 'lib/helpers')
+		partials: path.join(options.basePath, 'views/partials')
 	};
 
 	// Load the application manifest and use it
@@ -183,7 +182,7 @@ function createExpressApp(options, paths) {
 		extname: 'html',
 		layoutsDir: paths.layouts,
 		partialsDir: paths.partials,
-		helpers: paths.helpers
+		helpers: options.handlebarsHelpers
 	});
 
 	app.engine('html', handlebars.engine);

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -47,7 +47,8 @@ function origamiService(options) {
 		public: path.join(options.basePath, 'public'),
 		views: path.join(options.basePath, 'views'),
 		layouts: path.join(options.basePath, 'views/layouts'),
-		partials: path.join(options.basePath, 'views/partials')
+		partials: path.join(options.basePath, 'views/partials'),
+		helpers: path.join(options.basePath, 'lib/helpers')
 	};
 
 	// Load the application manifest and use it
@@ -181,8 +182,10 @@ function createExpressApp(options, paths) {
 		defaultLayout: options.defaultLayout,
 		extname: 'html',
 		layoutsDir: paths.layouts,
-		partialsDir: paths.partials
+		partialsDir: paths.partials,
+		helpers: paths.helpers
 	});
+
 	app.engine('html', handlebars.engine);
 	app.set('views', paths.views);
 	app.set('view engine', 'html');

--- a/test/unit/lib/origami-service.test.js
+++ b/test/unit/lib/origami-service.test.js
@@ -81,6 +81,10 @@ describe('lib/origami-service', () => {
 			assert.strictEqual(origamiService.defaults.defaultLayout, false);
 		});
 
+		it('has an `handlebarsHelpers` property', () => {
+			assert.deepEqual(origamiService.defaults.handlebarsHelpers, {});
+		});
+
 		it('has an `environment` property', () => {
 			assert.strictEqual(origamiService.defaults.environment, 'development');
 		});
@@ -154,6 +158,7 @@ describe('lib/origami-service', () => {
 				},
 				basePath: 'mock-base-path',
 				defaultLayout: 'mock-default-layout',
+				handlebarsHelpers: { helps: () => 'Offer mock help'},
 				environment: 'test',
 				exposeErrorEndpoint: false,
 				goodToGoTest: sinon.spy(),
@@ -213,7 +218,8 @@ describe('lib/origami-service', () => {
 				defaultLayout: options.defaultLayout,
 				extname: 'html',
 				layoutsDir: 'mock-base-path/views/layouts',
-				partialsDir: 'mock-base-path/views/partials'
+				partialsDir: 'mock-base-path/views/partials',
+				helpers: options.handlebarsHelpers
 			});
 			assert.calledOnce(express.mockApp.engine);
 			assert.calledWithExactly(express.mockApp.engine, 'html', expressHandlebars.mockInstance.engine);


### PR DESCRIPTION
Looks for handlebars helpers in the service path `('lib/helpers')` to apply to the express-handlebars config. 