### PR TITLE
Skip logging for healthcheck endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Some middleware will also be mounted by default, in this order:
 
   - [Express Web Service]: To provide `/__about`, `/__health`, and `/__gtg` endpoints (as well as `/__error` if configured to)
   - [Next Metrics]: To send request/response data to Graphite
-  - [Morgan]: To log requests
+  - [Morgan]: To log requests (requests to `/__gtg`, `/__health`, and `/favicon.ico` are never logged)
   - [Static]: To serve files in the application's `public` folder
 
 ### Options

--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -196,7 +196,11 @@ function createExpressApp(options, paths) {
 // Function to determine whether request logging
 // should be skipped
 function requestLogSkip(request) {
-	return (request.path === '/favicon.ico');
+	return (
+		request.path === '/__gtg' ||
+		request.path === '/__health' ||
+		request.path === '/favicon.ico'
+	);
 }
 
 // Promisify the starting of an Express app

--- a/test/unit/lib/origami-service.test.js
+++ b/test/unit/lib/origami-service.test.js
@@ -309,6 +309,32 @@ describe('lib/origami-service', () => {
 				assert.isFalse(app);
 			});
 
+			describe('when `request.path` is `"/__gtg"`', () => {
+
+				beforeEach(() => {
+					express.mockRequest.path = '/__gtg';
+					app = skip(express.mockRequest);
+				});
+
+				it('returns `true`', () => {
+					assert.isTrue(app);
+				});
+
+			});
+
+			describe('when `request.path` is `"/__health"`', () => {
+
+				beforeEach(() => {
+					express.mockRequest.path = '/__health';
+					app = skip(express.mockRequest);
+				});
+
+				it('returns `true`', () => {
+					assert.isTrue(app);
+				});
+
+			});
+
 			describe('when `request.path` is `"/favicon.ico"`', () => {
 
 				beforeEach(() => {


### PR DESCRIPTION
The `/__health` and `/__gtg` cause a lot of noise in our Splunk logs,
I think it's worth removing them. I'm questioning whether this should be
classed as a breaking change or not 🤔

Fixes #66