### PR TITLE
Prevent Handlebars' stupid auto-indent

### DIFF
--- a/lib/origami-service.js
+++ b/lib/origami-service.js
@@ -183,7 +183,10 @@ function createExpressApp(options, paths) {
 		extname: 'html',
 		layoutsDir: paths.layouts,
 		partialsDir: paths.partials,
-		helpers: options.handlebarsHelpers
+		helpers: options.handlebarsHelpers,
+		compilerOptions: {
+			preventIndent: true
+		}
 	});
 
 	app.engine('html', handlebars.engine);

--- a/test/unit/lib/origami-service.test.js
+++ b/test/unit/lib/origami-service.test.js
@@ -219,7 +219,10 @@ describe('lib/origami-service', () => {
 				extname: 'html',
 				layoutsDir: 'mock-base-path/views/layouts',
 				partialsDir: 'mock-base-path/views/partials',
-				helpers: options.handlebarsHelpers
+				helpers: options.handlebarsHelpers,
+				compilerOptions: {
+					preventIndent: true
+				}
 			});
 			assert.calledOnce(express.mockApp.engine);
 			assert.calledWithExactly(express.mockApp.engine, 'html', expressHandlebars.mockInstance.engine);


### PR DESCRIPTION
This breaks `<pre>` element whitespace, I'm surprised we haven't
encountered that yet!