### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "Code scanning - action"
 
 on:
   push:
-    branches: [master, ]
+    branches: [$default-branch, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [$default-branch]
   schedule:
     - cron: '0 10 * * 3'
 

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -7,7 +7,7 @@ on:
 # on:
 #   push:
 #     branches:
-#       - 'master'
+#       - $default-branch
 
 jobs:
   run:
@@ -18,5 +18,5 @@ jobs:
         with:
           github_token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
           # branch: "npm-audit-fix"
-          # default_branch: "master"
+          # default_branch: $default-branch
           # commit_title: "chore(deps): npm audit fix"


### PR DESCRIPTION
This will help with any future work on renaming the default branch name.