### PR TITLE
do not log server errors

### DIFF
--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -2,7 +2,6 @@
 
 const cacheControl = require('./cache-control');
 const defaults = require('lodash/defaults');
-const querystring = require('querystring');
 const raven = require('raven');
 
 module.exports = errorHandler;
@@ -22,44 +21,6 @@ function errorHandler(options) {
 		const ft = request.app.ft;
 		const status = error.status || error.statusCode || error.status_code || 500;
 		const showStack = (status >= 500 && ft.options.environment !== 'production');
-
-		// Log server errors
-		if (status >= 500) {
-			const errorMessage = JSON.stringify(error.message);
-			const errorStatus = JSON.stringify(status);
-			const errorUrl = JSON.stringify(request.url);
-			let errorStack;
-
-			// Build error stack
-			if (error.stack) {
-				// Error stacks are multi-line strings which are
-				// padded with whitespace to indent them. We need to
-				// remove this whitespace and escape newlines so
-				// that Splunk registers only one event per error
-				errorStack = error.stack
-					// Split into lines
-					.split('\n')
-					// Remove the leading whitespace
-					.map(line => line.trim())
-					// Ignore the first line – this is just
-					// repeating the error message that we already
-					// log separately
-					.slice(1)
-					// Turn back into a multi-line string
-					.join('\n');
-				// Using JSON stringify adds quotes around the string
-				// and escapes any quotes or newlines within it
-				errorStack = JSON.stringify(errorStack);
-			}
-			const errorDetail = decodeURIComponent(querystring.stringify({
-				message: errorMessage,
-				status: errorStatus,
-				stack: errorStack || 'null', // null has to be a string here
-				url: errorUrl
-			}, ' '));
-			ft.log.error(`Server Error ${errorDetail}`);
-		}
-
 		// Attempt to render the error page
 		const context = {
 			title: `Error ${status}`,

--- a/test/unit/lib/middleware/error-handler.test.js
+++ b/test/unit/lib/middleware/error-handler.test.js
@@ -96,9 +96,8 @@ describe('lib/middleware/error-handler', () => {
 				assert.calledWith(raven.mockErrorMiddleware, error, express.mockRequest, express.mockResponse);
 			});
 
-			it('logs the error and escaped error stack', () => {
-				assert.calledOnce(log.error);
-				assert.match(log.error.firstCall.args[0], /^Server Error message="Oops" status=500 stack="[^"\n]+" url="mock-url"$/);
+			it('does not log the error', () => {
+				assert.notCalled(log.error);
 			});
 
 			it('creates a cacheControl middleware', () => {
@@ -272,9 +271,8 @@ describe('lib/middleware/error-handler', () => {
 					middleware(error, express.mockRequest, express.mockResponse, next);
 				});
 
-				it('logs the error and null error stack', () => {
-					assert.calledOnce(log.error);
-					assert.calledWithExactly(log.error, 'Server Error message="Oops" status=500 stack=null url="mock-url"');
+				it('does not log the error', () => {
+					assert.notCalled(log.error);
 				});
 
 			});


### PR DESCRIPTION
server errors are recorded in Sentry via raven, no need to log them to stderr as well -- if we want to write to stderr then we should sanitise the output before writing it